### PR TITLE
Fix Prisma trade updates inside transactions

### DIFF
--- a/src/application/dto/trade.dto.ts
+++ b/src/application/dto/trade.dto.ts
@@ -1,0 +1,34 @@
+// ============================================================================
+// RUTA: src/application/dto/trade.dto.ts
+// ============================================================================
+
+import { z } from 'zod';
+
+const SnowflakeSchema = z
+  .string()
+  .trim()
+  .regex(/^\d{17,20}$/u, 'Invalid Discord ID');
+
+export const SubmitTradeDataSchema = z.object({
+  ticketId: z.number().int().positive('Invalid ticket identifier'),
+  userId: SnowflakeSchema,
+  robloxUsername: z
+    .string()
+    .trim()
+    .min(3, 'El usuario de Roblox debe tener al menos 3 caracteres.')
+    .max(50, 'El usuario de Roblox no puede exceder 50 caracteres.'),
+  offerDescription: z
+    .string()
+    .trim()
+    .min(5, 'Describe brevemente qué ofreces en el trade.')
+    .max(1000, 'La descripción del trade no puede exceder 1000 caracteres.'),
+});
+
+export type SubmitTradeDataDTO = z.infer<typeof SubmitTradeDataSchema>;
+
+export const ConfirmTradeSchema = z.object({
+  ticketId: z.number().int().positive('Invalid ticket identifier'),
+  userId: SnowflakeSchema,
+});
+
+export type ConfirmTradeDTO = z.infer<typeof ConfirmTradeSchema>;

--- a/src/application/services/TradePanelStore.ts
+++ b/src/application/services/TradePanelStore.ts
@@ -1,0 +1,17 @@
+// ============================================================================
+// RUTA: src/application/services/TradePanelStore.ts
+// ============================================================================
+
+const store = new Map<string, string>();
+
+export const tradePanelStore = {
+  get(channelId: string): string | undefined {
+    return store.get(channelId);
+  },
+  set(channelId: string, messageId: string): void {
+    store.set(channelId, messageId);
+  },
+  delete(channelId: string): void {
+    store.delete(channelId);
+  },
+};

--- a/src/application/usecases/middleman/ConfirmTradeUseCase.ts
+++ b/src/application/usecases/middleman/ConfirmTradeUseCase.ts
@@ -1,0 +1,85 @@
+// ============================================================================
+// RUTA: src/application/usecases/middleman/ConfirmTradeUseCase.ts
+// ============================================================================
+
+import type { Logger } from 'pino';
+
+import { type ConfirmTradeDTO,ConfirmTradeSchema } from '@/application/dto/trade.dto';
+import type { ITicketRepository } from '@/domain/repositories/ITicketRepository';
+import type { ITradeRepository } from '@/domain/repositories/ITradeRepository';
+import {
+  TicketClosedError,
+  TicketNotFoundError,
+  TradeAlreadyConfirmedError,
+  TradeDataNotFoundError,
+  UnauthorizedActionError,
+} from '@/shared/errors/domain.errors';
+
+interface ConfirmTradeResult {
+  readonly ticketConfirmed: boolean;
+}
+
+export class ConfirmTradeUseCase {
+  public constructor(
+    private readonly ticketRepo: ITicketRepository,
+    private readonly tradeRepo: ITradeRepository,
+    private readonly logger: Logger,
+  ) {}
+
+  public async execute(dto: ConfirmTradeDTO): Promise<ConfirmTradeResult> {
+    const payload = ConfirmTradeSchema.parse(dto);
+    const ticket = await this.ticketRepo.findById(payload.ticketId);
+
+    if (!ticket) {
+      throw new TicketNotFoundError(String(payload.ticketId));
+    }
+
+    if (!ticket.isOpen()) {
+      throw new TicketClosedError(ticket.id);
+    }
+
+    const userId = BigInt(payload.userId);
+    const isParticipant =
+      ticket.isOwnedBy(userId) || (await this.ticketRepo.isParticipant(ticket.id, userId));
+
+    if (!isParticipant) {
+      throw new UnauthorizedActionError('middleman:trade:confirm');
+    }
+
+    const trades = await this.tradeRepo.findByTicketId(ticket.id);
+    const trade = trades.find((current) => current.userId === userId) ?? null;
+
+    if (!trade) {
+      throw new TradeDataNotFoundError(payload.userId);
+    }
+
+    if (trade.confirmed) {
+      throw new TradeAlreadyConfirmedError();
+    }
+
+    trade.confirm();
+    await this.tradeRepo.update(trade);
+
+    const everyoneHasTrade = trades.length >= 2;
+    const allConfirmed = everyoneHasTrade && trades.every((current) => current.confirmed);
+
+    if (allConfirmed) {
+      ticket.confirm();
+      await this.ticketRepo.update(ticket);
+
+      this.logger.info(
+        { ticketId: ticket.id, userId: payload.userId },
+        'Ambas partes confirmaron el trade. Ticket marcado como listo.',
+      );
+
+      return { ticketConfirmed: true };
+    }
+
+    this.logger.info(
+      { ticketId: ticket.id, userId: payload.userId },
+      'Participante confirmó trade. A la espera del resto.',
+    );
+
+    return { ticketConfirmed: false };
+  }
+}

--- a/src/application/usecases/middleman/SubmitTradeDataUseCase.ts
+++ b/src/application/usecases/middleman/SubmitTradeDataUseCase.ts
@@ -1,0 +1,92 @@
+// ============================================================================
+// RUTA: src/application/usecases/middleman/SubmitTradeDataUseCase.ts
+// ============================================================================
+
+import type { Logger } from 'pino';
+
+import { type SubmitTradeDataDTO, SubmitTradeDataSchema } from '@/application/dto/trade.dto';
+import type { Trade } from '@/domain/entities/Trade';
+import type { TradeItem } from '@/domain/entities/types';
+import type { ITicketRepository } from '@/domain/repositories/ITicketRepository';
+import type { ITradeRepository } from '@/domain/repositories/ITradeRepository';
+import {
+  TicketClosedError,
+  TicketNotFoundError,
+  UnauthorizedActionError,
+} from '@/shared/errors/domain.errors';
+
+const DESCRIPTION_MAX_LENGTH = 240;
+
+const buildTradeItem = (description: string): TradeItem => ({
+  name: description.slice(0, DESCRIPTION_MAX_LENGTH),
+  quantity: 1,
+  metadata: { description },
+});
+
+export class SubmitTradeDataUseCase {
+  public constructor(
+    private readonly ticketRepo: ITicketRepository,
+    private readonly tradeRepo: ITradeRepository,
+    private readonly logger: Logger,
+  ) {}
+
+  public async execute(dto: SubmitTradeDataDTO): Promise<Trade> {
+    const payload = SubmitTradeDataSchema.parse(dto);
+    const ticket = await this.ticketRepo.findById(payload.ticketId);
+
+    if (!ticket) {
+      throw new TicketNotFoundError(String(payload.ticketId));
+    }
+
+    if (!ticket.isOpen()) {
+      throw new TicketClosedError(ticket.id);
+    }
+
+    const userId = BigInt(payload.userId);
+    const isParticipant =
+      ticket.isOwnedBy(userId) || (await this.ticketRepo.isParticipant(ticket.id, userId));
+
+    if (!isParticipant) {
+      throw new UnauthorizedActionError('middleman:trade:data');
+    }
+
+    const trades = await this.tradeRepo.findByTicketId(ticket.id);
+    const existingTrade = trades.find((trade) => trade.userId === userId) ?? null;
+    const normalizedDescription = payload.offerDescription.trim();
+    const item = buildTradeItem(normalizedDescription);
+
+    if (existingTrade) {
+      existingTrade.updateRobloxProfile({ username: payload.robloxUsername });
+      existingTrade.replaceItems([item]);
+      existingTrade.resetConfirmation();
+
+      await this.tradeRepo.update(existingTrade);
+      this.logger.info(
+        {
+          ticketId: ticket.id,
+          userId: payload.userId,
+        },
+        'Datos de trade actualizados.',
+      );
+
+      return existingTrade;
+    }
+
+    const trade = await this.tradeRepo.create({
+      ticketId: ticket.id,
+      userId,
+      robloxUsername: payload.robloxUsername,
+      items: [item],
+    });
+
+    this.logger.info(
+      {
+        ticketId: ticket.id,
+        userId: payload.userId,
+      },
+      'Datos de trade registrados por primera vez.',
+    );
+
+    return trade;
+  }
+}

--- a/src/domain/entities/Ticket.ts
+++ b/src/domain/entities/Ticket.ts
@@ -55,6 +55,14 @@ export class Ticket {
     this.assignedMiddlemanId = undefined;
   }
 
+  public confirm(): void {
+    if (this.status !== TicketStatus.OPEN && this.status !== TicketStatus.CLAIMED) {
+      throw new InvalidTicketStateError(this.status, TicketStatus.CONFIRMED);
+    }
+
+    this.status = TicketStatus.CONFIRMED;
+  }
+
   public isOwnedBy(userId: bigint): boolean {
     return this.ownerId === userId;
   }

--- a/src/domain/repositories/IMiddlemanRepository.ts
+++ b/src/domain/repositories/IMiddlemanRepository.ts
@@ -13,10 +13,23 @@ export interface MiddlemanClaim {
   readonly forcedClose?: boolean;
 }
 
+export interface MiddlemanProfile {
+  readonly userId: bigint;
+  readonly robloxUsername: string;
+  readonly robloxUserId: bigint | null;
+  readonly vouches: number;
+  readonly ratingSum: number;
+  readonly ratingCount: number;
+}
+
 export interface IMiddlemanRepository extends Transactional<IMiddlemanRepository> {
   isMiddleman(userId: bigint): Promise<boolean>;
   getClaimByTicket(ticketId: number): Promise<MiddlemanClaim | null>;
   createClaim(ticketId: number, middlemanId: bigint): Promise<void>;
   markClosed(ticketId: number, payload: { closedAt: Date; forcedClose?: boolean }): Promise<void>;
   markReviewRequested(ticketId: number, requestedAt: Date): Promise<void>;
+  upsertProfile(data: { userId: bigint; robloxUsername: string; robloxUserId?: bigint | null }): Promise<void>;
+  updateProfile(data: { userId: bigint; robloxUsername?: string | null; robloxUserId?: bigint | null }): Promise<void>;
+  getProfile(userId: bigint): Promise<MiddlemanProfile | null>;
+  listTopProfiles(limit?: number): Promise<readonly MiddlemanProfile[]>;
 }

--- a/src/infrastructure/repositories/PrismaMiddlemanRepository.ts
+++ b/src/infrastructure/repositories/PrismaMiddlemanRepository.ts
@@ -4,7 +4,11 @@
 
 import type { Prisma, PrismaClient } from '@prisma/client';
 
-import type { IMiddlemanRepository, MiddlemanClaim } from '@/domain/repositories/IMiddlemanRepository';
+import type {
+  IMiddlemanRepository,
+  MiddlemanClaim,
+  MiddlemanProfile,
+} from '@/domain/repositories/IMiddlemanRepository';
 import type { TransactionContext } from '@/domain/repositories/transaction';
 
 type PrismaClientLike = PrismaClient | Prisma.TransactionClient;
@@ -58,6 +62,123 @@ export class PrismaMiddlemanRepository implements IMiddlemanRepository {
     });
   }
 
+  public async upsertProfile(data: { userId: bigint; robloxUsername: string; robloxUserId?: bigint | null }): Promise<void> {
+    await this.prisma.middleman.upsert({
+      where: { userId: data.userId },
+      update: {
+        robloxUsername: data.robloxUsername,
+        robloxUserId: data.robloxUserId ?? null,
+      },
+      create: {
+        userId: data.userId,
+        robloxUsername: data.robloxUsername,
+        robloxUserId: data.robloxUserId ?? null,
+      },
+    });
+  }
+
+  public async updateProfile(data: {
+    userId: bigint;
+    robloxUsername?: string | null;
+    robloxUserId?: bigint | null;
+  }): Promise<void> {
+    try {
+      await this.prisma.middleman.update({
+        where: { userId: data.userId },
+        data: {
+          robloxUsername: data.robloxUsername ?? undefined,
+          robloxUserId: data.robloxUserId ?? undefined,
+        },
+      });
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
+        await this.upsertProfile({
+          userId: data.userId,
+          robloxUsername: data.robloxUsername ?? 'Sin registrar',
+          robloxUserId: data.robloxUserId ?? null,
+        });
+        return;
+      }
+
+      throw error;
+    }
+  }
+
+  public async getProfile(userId: bigint): Promise<MiddlemanProfile | null> {
+    const rows = await this.prisma.$queryRaw<Array<{
+      user_id: bigint;
+      roblox_username: string;
+      roblox_user_id: bigint | null;
+      vouches_count: bigint | number | null;
+      rating_sum: bigint | number | null;
+      rating_count: bigint | number | null;
+    }>>`
+      SELECT m.user_id, m.roblox_username, m.roblox_user_id,
+        COALESCE(vc.vouches_count, 0) AS vouches_count,
+        COALESCE(rr.rating_sum, 0) AS rating_sum,
+        COALESCE(rr.rating_count, 0) AS rating_count
+      FROM middlemen m
+      LEFT JOIN (
+        SELECT middleman_id, COUNT(*) AS vouches_count
+        FROM mm_claims
+        WHERE vouched = TRUE
+        GROUP BY middleman_id
+      ) vc ON vc.middleman_id = m.user_id
+      LEFT JOIN (
+        SELECT middleman_id, SUM(stars) AS rating_sum, COUNT(*) AS rating_count
+        FROM mm_reviews
+        GROUP BY middleman_id
+      ) rr ON rr.middleman_id = m.user_id
+      WHERE m.user_id = ${userId}
+      LIMIT 1;
+    `;
+
+    const row = rows[0];
+    return row ? PrismaMiddlemanRepository.mapProfile(row) : null;
+  }
+
+  public async listTopProfiles(limit = 10): Promise<readonly MiddlemanProfile[]> {
+    const safeLimit = Math.max(1, Math.min(50, Number.isFinite(limit) ? Number(limit) : 10));
+
+    const rows = await this.prisma.$queryRaw<Array<{
+      user_id: bigint;
+      roblox_username: string;
+      roblox_user_id: bigint | null;
+      vouches_count: bigint | number | null;
+      rating_sum: bigint | number | null;
+      rating_count: bigint | number | null;
+    }>>`
+      SELECT stats.user_id, stats.roblox_username, stats.roblox_user_id,
+        stats.vouches_count, stats.rating_sum, stats.rating_count
+      FROM (
+        SELECT m.user_id, m.roblox_username, m.roblox_user_id,
+          COALESCE(vc.vouches_count, 0) AS vouches_count,
+          COALESCE(rr.rating_sum, 0) AS rating_sum,
+          COALESCE(rr.rating_count, 0) AS rating_count,
+          m.updated_at
+        FROM middlemen m
+        LEFT JOIN (
+          SELECT middleman_id, COUNT(*) AS vouches_count
+          FROM mm_claims
+          WHERE vouched = TRUE
+          GROUP BY middleman_id
+        ) vc ON vc.middleman_id = m.user_id
+        LEFT JOIN (
+          SELECT middleman_id, SUM(stars) AS rating_sum, COUNT(*) AS rating_count
+          FROM mm_reviews
+          GROUP BY middleman_id
+        ) rr ON rr.middleman_id = m.user_id
+      ) stats
+      ORDER BY stats.vouches_count DESC,
+        CASE WHEN stats.rating_count > 0 THEN stats.rating_sum / stats.rating_count ELSE NULL END DESC,
+        stats.rating_count DESC,
+        stats.updated_at DESC
+      LIMIT ${safeLimit};
+    `;
+
+    return rows.map((row) => PrismaMiddlemanRepository.mapProfile(row));
+  }
+
   private toDomain(claim: PrismaClaim): MiddlemanClaim {
     return {
       ticketId: claim.ticketId,
@@ -71,5 +192,23 @@ export class PrismaMiddlemanRepository implements IMiddlemanRepository {
 
   private static isTransactionClient(value: TransactionContext): value is Prisma.TransactionClient {
     return typeof value === 'object' && value !== null && 'middlemanClaim' in value;
+  }
+
+  private static mapProfile(row: {
+    user_id: bigint;
+    roblox_username: string;
+    roblox_user_id: bigint | null;
+    vouches_count: bigint | number | null;
+    rating_sum: bigint | number | null;
+    rating_count: bigint | number | null;
+  }): MiddlemanProfile {
+    return {
+      userId: row.user_id,
+      robloxUsername: row.roblox_username,
+      robloxUserId: row.roblox_user_id,
+      vouches: Number(row.vouches_count ?? 0),
+      ratingSum: Number(row.rating_sum ?? 0),
+      ratingCount: Number(row.rating_count ?? 0),
+    };
   }
 }

--- a/src/presentation/commands/index.ts
+++ b/src/presentation/commands/index.ts
@@ -12,9 +12,10 @@ import {
 import { helpCommand } from '@/presentation/commands/general/help';
 import { pingCommand } from '@/presentation/commands/general/ping';
 import { middlemanCommand } from '@/presentation/commands/middleman/middleman';
+import { middlemanDirectoryCommand } from '@/presentation/commands/middleman/mm';
 import type { Command } from '@/presentation/commands/types';
 
-const commands: Command[] = [pingCommand, helpCommand, middlemanCommand];
+const commands: Command[] = [pingCommand, helpCommand, middlemanCommand, middlemanDirectoryCommand];
 
 registerCommands(commands);
 

--- a/src/presentation/commands/middleman/mm.ts
+++ b/src/presentation/commands/middleman/mm.ts
@@ -1,0 +1,243 @@
+// ============================================================================
+// RUTA: src/presentation/commands/middleman/mm.ts
+// ============================================================================
+
+import { type ChatInputCommandInteraction,PermissionFlagsBits, SlashCommandBuilder } from 'discord.js';
+
+import { prisma } from '@/infrastructure/db/prisma';
+import { PrismaMiddlemanRepository } from '@/infrastructure/repositories/PrismaMiddlemanRepository';
+import type { Command } from '@/presentation/commands/types';
+import { embedFactory } from '@/presentation/embeds/EmbedFactory';
+import { mapErrorToDiscordResponse } from '@/shared/errors/discord-error-mapper';
+import { UnauthorizedActionError } from '@/shared/errors/domain.errors';
+import { logger } from '@/shared/logger/pino';
+
+const middlemanDirectoryRepo = new PrismaMiddlemanRepository(prisma);
+
+const ensureCanManageDirectory = (interaction: ChatInputCommandInteraction): void => {
+  if (interaction.memberPermissions?.has(PermissionFlagsBits.ManageGuild)) {
+    return;
+  }
+
+  throw new UnauthorizedActionError('middleman:directory');
+};
+
+const handleAdd = async (interaction: ChatInputCommandInteraction): Promise<void> => {
+  ensureCanManageDirectory(interaction);
+
+  const target = interaction.options.getUser('usuario', true);
+  const robloxUsername = interaction.options.getString('roblox', true);
+
+  await middlemanDirectoryRepo.upsertProfile({
+    userId: BigInt(target.id),
+    robloxUsername,
+  });
+
+  await interaction.reply({
+    embeds: [
+      embedFactory.success({
+        title: 'Middleman registrado',
+        description: `${target.toString()} ahora forma parte del directorio de middlemen con el usuario Roblox **${robloxUsername}**.`,
+      }),
+    ],
+    ephemeral: true,
+  });
+};
+
+const handleSet = async (interaction: ChatInputCommandInteraction): Promise<void> => {
+  ensureCanManageDirectory(interaction);
+
+  const target = interaction.options.getUser('usuario', true);
+  const robloxUsername = interaction.options.getString('roblox');
+
+  await middlemanDirectoryRepo.updateProfile({
+    userId: BigInt(target.id),
+    robloxUsername: robloxUsername ?? null,
+  });
+
+  await interaction.reply({
+    embeds: [
+      embedFactory.success({
+        title: 'Middleman actualizado',
+        description: robloxUsername
+          ? `${target.toString()} ahora utiliza el usuario Roblox **${robloxUsername}**.`
+          : `${target.toString()} mantiene su información pero se actualizó la ficha.`,
+      }),
+    ],
+    ephemeral: true,
+  });
+};
+
+const handleStats = async (interaction: ChatInputCommandInteraction): Promise<void> => {
+  const target = interaction.options.getUser('usuario') ?? interaction.user;
+  const profile = await middlemanDirectoryRepo.getProfile(BigInt(target.id));
+
+  if (!profile) {
+    await interaction.reply({
+      embeds: [
+        embedFactory.warning({
+          title: 'Sin datos registrados',
+          description: `${target.toString()} todavía no cuenta con estadísticas como middleman.`,
+        }),
+      ],
+      ephemeral: true,
+    });
+    return;
+  }
+
+  const average = profile.ratingCount > 0 ? profile.ratingSum / profile.ratingCount : 0;
+  const description = [
+    `• Usuario de Roblox: **${profile.robloxUsername}**`,
+    `• Vouches registrados: **${profile.vouches}**`,
+    `• Valoraciones recibidas: **${profile.ratingCount}**`,
+    `• Promedio actual: **${average.toFixed(2)} ⭐**`,
+  ].join('\n');
+
+  await interaction.reply({
+    embeds: [
+      embedFactory.info({
+        title: `Estadísticas de ${target.username}`,
+        description,
+      }),
+    ],
+    ephemeral: true,
+  });
+};
+
+const handleList = async (interaction: ChatInputCommandInteraction): Promise<void> => {
+  const limit = interaction.options.getInteger('limite') ?? 10;
+  const profiles = await middlemanDirectoryRepo.listTopProfiles(limit);
+
+  if (profiles.length === 0) {
+    await interaction.reply({
+      embeds: [
+        embedFactory.info({
+          title: 'Directorio vacío',
+          description: 'Aún no se registran middlemen en el sistema.',
+        }),
+      ],
+      ephemeral: true,
+    });
+    return;
+  }
+
+  const lines = profiles.map((profile, index) => {
+    const average = profile.ratingCount > 0 ? profile.ratingSum / profile.ratingCount : 0;
+    return `${index + 1}. <@${profile.userId.toString()}> — Roblox: **${profile.robloxUsername}** | Vouches: ${profile.vouches} | Rating: ${average.toFixed(2)} (${profile.ratingCount})`;
+  });
+
+  await interaction.reply({
+    embeds: [
+      embedFactory.info({
+        title: 'Top middlemen',
+        description: lines.join('\n'),
+      }),
+    ],
+    ephemeral: true,
+  });
+};
+
+export const middlemanDirectoryCommand: Command = {
+  data: new SlashCommandBuilder()
+    .setName('mm')
+    .setDescription('Herramientas para gestionar el directorio de middlemen')
+    .addSubcommand((sub) =>
+      sub
+        .setName('add')
+        .setDescription('Registrar un nuevo middleman')
+        .addUserOption((option) => option.setName('usuario').setDescription('Usuario de Discord').setRequired(true))
+        .addStringOption((option) =>
+          option
+            .setName('roblox')
+            .setDescription('Usuario de Roblox asociado')
+            .setMinLength(3)
+            .setMaxLength(50)
+            .setRequired(true),
+        ),
+    )
+    .addSubcommand((sub) =>
+      sub
+        .setName('set')
+        .setDescription('Actualizar la ficha de un middleman existente')
+        .addUserOption((option) => option.setName('usuario').setDescription('Usuario de Discord').setRequired(true))
+        .addStringOption((option) =>
+          option
+            .setName('roblox')
+            .setDescription('Nuevo usuario de Roblox (opcional)')
+            .setMinLength(3)
+            .setMaxLength(50)
+            .setRequired(false),
+        ),
+    )
+    .addSubcommand((sub) =>
+      sub
+        .setName('stats')
+        .setDescription('Consultar estadísticas de un middleman')
+        .addUserOption((option) => option.setName('usuario').setDescription('Usuario a consultar').setRequired(false)),
+    )
+    .addSubcommand((sub) =>
+      sub
+        .setName('list')
+        .setDescription('Mostrar el top de middlemen registrados')
+        .addIntegerOption((option) =>
+          option
+            .setName('limite')
+            .setDescription('Cantidad de resultados a mostrar (1-50)')
+            .setMinValue(1)
+            .setMaxValue(50)
+            .setRequired(false),
+        ),
+    ),
+  category: 'Middleman',
+  examples: ['/mm add @usuario Mikokorikos', '/mm stats @usuario', '/mm list'],
+  async execute(interaction) {
+    try {
+      const subcommand = interaction.options.getSubcommand();
+
+      switch (subcommand) {
+        case 'add':
+          await handleAdd(interaction);
+          break;
+        case 'set':
+          await handleSet(interaction);
+          break;
+        case 'stats':
+          await handleStats(interaction);
+          break;
+        case 'list':
+          await handleList(interaction);
+          break;
+        default:
+          await interaction.reply({
+            embeds: [
+              embedFactory.warning({
+                title: 'Acción no disponible',
+                description: 'El subcomando solicitado no está implementado.',
+              }),
+            ],
+            ephemeral: true,
+          });
+      }
+    } catch (error) {
+      const { shouldLogStack, referenceId, embeds, ...payload } = mapErrorToDiscordResponse(error);
+
+      if (shouldLogStack) {
+        logger.error({ err: error, referenceId }, 'Error inesperado en comando /mm.');
+      } else {
+        logger.warn({ err: error, referenceId }, 'Error controlado en comando /mm.');
+      }
+
+      await interaction.reply({
+        ...payload,
+        embeds:
+          embeds ?? [
+            embedFactory.error({
+              title: 'No se pudo completar la acción',
+              description: 'Ocurrió un problema al ejecutar el comando.',
+            }),
+          ],
+        ephemeral: true,
+      });
+    }
+  },
+};

--- a/src/presentation/components/buttons/TradePanelButtons.ts
+++ b/src/presentation/components/buttons/TradePanelButtons.ts
@@ -1,0 +1,28 @@
+// ============================================================================
+// RUTA: src/presentation/components/buttons/TradePanelButtons.ts
+// ============================================================================
+
+import { ActionRowBuilder, ButtonBuilder, ButtonStyle } from 'discord.js';
+
+export const TRADE_DATA_BUTTON_ID = 'middleman:trade:data';
+export const TRADE_CONFIRM_BUTTON_ID = 'middleman:trade:confirm';
+export const TRADE_HELP_BUTTON_ID = 'middleman:trade:help';
+
+export const buildTradePanelButtons = (): ActionRowBuilder<ButtonBuilder> =>
+  new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(TRADE_DATA_BUTTON_ID)
+      .setLabel('Mis datos de trade')
+      .setEmoji('📝')
+      .setStyle(ButtonStyle.Primary),
+    new ButtonBuilder()
+      .setCustomId(TRADE_CONFIRM_BUTTON_ID)
+      .setLabel('Confirmar trade')
+      .setEmoji('✅')
+      .setStyle(ButtonStyle.Success),
+    new ButtonBuilder()
+      .setCustomId(TRADE_HELP_BUTTON_ID)
+      .setLabel('Pedir ayuda')
+      .setEmoji('🚨')
+      .setStyle(ButtonStyle.Danger),
+  );

--- a/src/presentation/components/modals/MiddlemanModal.ts
+++ b/src/presentation/components/modals/MiddlemanModal.ts
@@ -6,6 +6,7 @@ import {
   ActionRowBuilder,
   ModalBuilder,
   type ModalSubmitInteraction,
+  type TextChannel,
   TextInputBuilder,
   TextInputStyle,
 } from 'discord.js';
@@ -58,6 +59,7 @@ export class MiddlemanModal {
   public static async handleSubmit(
     interaction: ModalSubmitInteraction,
     useCase: OpenMiddlemanChannelUseCase,
+    options: { renderPanel?: (channel: TextChannel, ticketId: number) => Promise<void> } = {},
   ): Promise<void> {
     if (!interaction.guild) {
       await interaction.reply({
@@ -105,6 +107,10 @@ export class MiddlemanModal {
         },
         interaction.guild,
       );
+
+      if (options.renderPanel) {
+        await options.renderPanel(channel, ticket.id);
+      }
 
       await interaction.editReply({
         embeds: [

--- a/src/presentation/components/modals/TradeModal.ts
+++ b/src/presentation/components/modals/TradeModal.ts
@@ -1,0 +1,58 @@
+// ============================================================================
+// RUTA: src/presentation/components/modals/TradeModal.ts
+// ============================================================================
+
+import {
+  ActionRowBuilder,
+  ModalBuilder,
+  type ModalSubmitInteraction,
+  TextInputBuilder,
+  TextInputStyle,
+} from 'discord.js';
+
+const ROBLOX_ID = 'roblox';
+const OFFER_ID = 'offer';
+
+export interface TradeModalPayload {
+  readonly robloxUsername: string;
+  readonly offerDescription: string;
+}
+
+export class TradeModal {
+  public static readonly CUSTOM_ID = 'middleman-trade';
+
+  public static build(): ModalBuilder {
+    return new ModalBuilder()
+      .setCustomId(TradeModal.CUSTOM_ID)
+      .setTitle('Mis datos de trade')
+      .addComponents(
+        new ActionRowBuilder<TextInputBuilder>().addComponents(
+          new TextInputBuilder()
+            .setCustomId(ROBLOX_ID)
+            .setLabel('Usuario de Roblox')
+            .setPlaceholder('Ej. Mikokorikos')
+            .setStyle(TextInputStyle.Short)
+            .setMinLength(3)
+            .setMaxLength(50)
+            .setRequired(true),
+        ),
+        new ActionRowBuilder<TextInputBuilder>().addComponents(
+          new TextInputBuilder()
+            .setCustomId(OFFER_ID)
+            .setLabel('¿Qué ofreces?')
+            .setPlaceholder('Incluye cantidades y moneda si aplica')
+            .setStyle(TextInputStyle.Paragraph)
+            .setMinLength(5)
+            .setMaxLength(1000)
+            .setRequired(true),
+        ),
+      );
+  }
+
+  public static parseFields(interaction: ModalSubmitInteraction): TradeModalPayload {
+    const robloxUsername = interaction.fields.getTextInputValue(ROBLOX_ID).trim();
+    const offerDescription = interaction.fields.getTextInputValue(OFFER_ID).trim();
+
+    return { robloxUsername, offerDescription };
+  }
+}

--- a/src/presentation/middleman/TradePanelRenderer.ts
+++ b/src/presentation/middleman/TradePanelRenderer.ts
@@ -1,0 +1,114 @@
+// ============================================================================
+// RUTA: src/presentation/middleman/TradePanelRenderer.ts
+// ============================================================================
+
+import type { TextChannel } from 'discord.js';
+import type { Logger } from 'pino';
+
+import { tradePanelStore } from '@/application/services/TradePanelStore';
+import type { Ticket } from '@/domain/entities/Ticket';
+import type { Trade } from '@/domain/entities/Trade';
+import { TicketStatus } from '@/domain/entities/types';
+import type { ITicketRepository } from '@/domain/repositories/ITicketRepository';
+import type { ITradeRepository } from '@/domain/repositories/ITradeRepository';
+import { buildTradePanelButtons } from '@/presentation/components/buttons/TradePanelButtons';
+import type { EmbedFactory } from '@/presentation/embeds/EmbedFactory';
+import { embedFactory } from '@/presentation/embeds/EmbedFactory';
+
+const hasDescriptionMetadata = (
+  value: unknown,
+): value is { description?: unknown } => typeof value === 'object' && value !== null && 'description' in value;
+
+const formatTradeSummary = (trade: Trade | undefined): string => {
+  if (!trade) {
+    return '• Datos: ❌ Sin registrar\n• Confirmación: ⏳ Pendiente';
+  }
+
+  const metadata = trade.items[0]?.metadata;
+  const rawDescription = hasDescriptionMetadata(metadata) ? metadata.description : null;
+  const description = typeof rawDescription === 'string' ? rawDescription : null;
+
+  return [
+    `• Roblox: **${trade.robloxUsername}**`,
+    description ? `• Oferta: ${String(description)}` : null,
+    `• Confirmación: ${trade.confirmed ? '✅ Registrada' : '⏳ Pendiente'}`,
+  ]
+    .filter(Boolean)
+    .join('\n');
+};
+
+const resolvePartnerId = (
+  ticket: Ticket,
+  participants: Awaited<ReturnType<ITicketRepository['listParticipants']>>,
+): bigint | null => {
+  const partner = participants.find((participant) => participant.userId !== ticket.ownerId);
+  return partner?.userId ?? null;
+};
+
+export class TradePanelRenderer {
+  public constructor(
+    private readonly ticketRepo: ITicketRepository,
+    private readonly tradeRepo: ITradeRepository,
+    private readonly logger: Logger,
+    private readonly embeds: EmbedFactory = embedFactory,
+  ) {}
+
+  public async render(channel: TextChannel, ticketId: number): Promise<void> {
+    const ticket = await this.ticketRepo.findById(ticketId);
+    if (!ticket) {
+      this.logger.warn({ ticketId, channelId: channel.id }, 'No se pudo renderizar panel: ticket inexistente.');
+      return;
+    }
+
+    const [participants, trades] = await Promise.all([
+      this.ticketRepo.listParticipants(ticket.id),
+      this.tradeRepo.findByTicketId(ticket.id),
+    ]);
+
+    const ownerMention = `<@${ticket.ownerId.toString()}>`;
+    const partnerId = resolvePartnerId(ticket, participants);
+    const partnerMention = partnerId ? `<@${partnerId.toString()}>` : 'Pendiente de registrar';
+
+    const ownerTrade = trades.find((trade) => trade.userId === ticket.ownerId);
+    const partnerTrade = partnerId ? trades.find((trade) => trade.userId === partnerId) : undefined;
+
+    const everyoneConfirmed =
+      trades.length >= 2 && trades.every((trade) => trade.confirmed) && ticket.status === TicketStatus.CONFIRMED;
+
+    const embed = this.embeds.middlemanPanel({
+      ticketId: ticket.id,
+      buyerTag: ownerMention,
+      sellerTag: partnerMention,
+      status: everyoneConfirmed ? 'Trade listo para middleman' : 'Pendiente de confirmación',
+      notes: [
+        `**${ownerMention}**\n${formatTradeSummary(ownerTrade)}`,
+        `**${partnerMention}**\n${formatTradeSummary(partnerTrade)}`,
+      ].join('\n\n'),
+    });
+
+    const payload: Parameters<TextChannel['send']>[0] = {
+      embeds: [embed],
+      components: [buildTradePanelButtons()],
+      allowedMentions: { parse: [] },
+    };
+
+    const storedMessageId = tradePanelStore.get(channel.id);
+
+    if (storedMessageId) {
+      try {
+        const message = await channel.messages.fetch(storedMessageId);
+        await message.edit(payload);
+        return;
+      } catch (error) {
+        this.logger.warn(
+          { channelId: channel.id, messageId: storedMessageId, err: error },
+          'No se pudo actualizar el panel existente, se enviará uno nuevo.',
+        );
+        tradePanelStore.delete(channel.id);
+      }
+    }
+
+    const message = await channel.send(payload);
+    tradePanelStore.set(channel.id, message.id);
+  }
+}

--- a/src/shared/config/env.ts
+++ b/src/shared/config/env.ts
@@ -48,6 +48,10 @@ export const EnvSchema = z.object({
     .string()
     .regex(/^\d{17,20}$/u, 'MIDDLEMAN_CATEGORY_ID debe ser un snowflake de Discord')
     .optional(),
+  MIDDLEMAN_ROLE_ID: z
+    .string()
+    .regex(/^\d{17,20}$/u, 'MIDDLEMAN_ROLE_ID debe ser un snowflake de Discord')
+    .optional(),
   REVIEW_CHANNEL_ID: z
     .string()
     .regex(/^\d{17,20}$/u, 'REVIEW_CHANNEL_ID debe ser un snowflake de Discord')

--- a/src/shared/errors/domain.errors.ts
+++ b/src/shared/errors/domain.errors.ts
@@ -103,6 +103,27 @@ export class TradesNotConfirmedError extends DedosError {
   }
 }
 
+export class TradeDataNotFoundError extends DedosError {
+  public constructor(userId: string) {
+    super({
+      code: 'TRADE_DATA_NOT_FOUND',
+      message: 'Debes registrar tus datos de trade antes de confirmar.',
+      metadata: { userId },
+      exposeMessage: true,
+    });
+  }
+}
+
+export class TradeAlreadyConfirmedError extends DedosError {
+  public constructor() {
+    super({
+      code: 'TRADE_ALREADY_CONFIRMED',
+      message: 'Ya confirmaste tu participación en este trade.',
+      exposeMessage: true,
+    });
+  }
+}
+
 export class ChannelCreationError extends DedosError {
   public constructor(reason?: string) {
     super({

--- a/tests/unit/application/usecases/ConfirmTradeUseCase.test.ts
+++ b/tests/unit/application/usecases/ConfirmTradeUseCase.test.ts
@@ -1,0 +1,144 @@
+import type { Logger } from 'pino';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ConfirmTradeDTO } from '@/application/dto/trade.dto';
+import { ConfirmTradeUseCase } from '@/application/usecases/middleman/ConfirmTradeUseCase';
+import { Ticket } from '@/domain/entities/Ticket';
+import { Trade } from '@/domain/entities/Trade';
+import { TicketStatus, TicketType } from '@/domain/entities/types';
+import type { ITicketRepository } from '@/domain/repositories/ITicketRepository';
+import type { ITradeRepository } from '@/domain/repositories/ITradeRepository';
+import { TradeStatus } from '@/domain/value-objects/TradeStatus';
+import { UnauthorizedActionError } from '@/shared/errors/domain.errors';
+
+class ConfirmTicketRepository implements ITicketRepository {
+  public ticket: Ticket | null = null;
+  public participants = new Set<string>();
+  public updated = false;
+
+  public withTransaction(): ITicketRepository {
+    return this;
+  }
+
+  public async create(): Promise<Ticket> {
+    throw new Error('not implemented');
+  }
+
+  public async findById(id: number): Promise<Ticket | null> {
+    if (!this.ticket || this.ticket.id !== id) {
+      return null;
+    }
+    return this.ticket;
+  }
+
+  public async findByChannelId(): Promise<Ticket | null> {
+    return null;
+  }
+
+  public async findOpenByOwner(): Promise<readonly Ticket[]> {
+    return [];
+  }
+
+  public async update(ticket: Ticket): Promise<void> {
+    this.ticket = ticket;
+    this.updated = true;
+  }
+
+  public async delete(): Promise<void> {}
+
+  public async countOpenByOwner(): Promise<number> {
+    return 0;
+  }
+
+  public async isParticipant(ticketId: number, userId: bigint): Promise<boolean> {
+    return this.ticket?.id === ticketId && this.participants.has(userId.toString());
+  }
+
+  public async listParticipants(): Promise<readonly { userId: bigint; role?: string | null; joinedAt?: Date }[]> {
+    return Array.from(this.participants).map((userId) => ({ userId: BigInt(userId) }));
+  }
+}
+
+class ConfirmTradeRepository implements ITradeRepository {
+  public trades: Trade[] = [];
+
+  public withTransaction(): ITradeRepository {
+    return this;
+  }
+
+  public async create(): Promise<Trade> {
+    throw new Error('not implemented');
+  }
+
+  public async findById(): Promise<Trade | null> {
+    return null;
+  }
+
+  public async findByTicketId(ticketId: number): Promise<readonly Trade[]> {
+    return this.trades.filter((trade) => trade.ticketId === ticketId);
+  }
+
+  public async findByUserId(): Promise<readonly Trade[]> {
+    return [];
+  }
+
+  public async update(): Promise<void> {}
+
+  public async delete(): Promise<void> {}
+}
+
+const createLogger = (): Logger =>
+  ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+    trace: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+    level: 'silent',
+  } as unknown as Logger);
+
+describe('ConfirmTradeUseCase', () => {
+  const OWNER_ID = '111111111111111111';
+  const PARTNER_ID = '222222222222222222';
+  const OTHER_ID = '333333333333333333';
+  let ticketRepo: ConfirmTicketRepository;
+  let tradeRepo: ConfirmTradeRepository;
+  let useCase: ConfirmTradeUseCase;
+
+  beforeEach(() => {
+    ticketRepo = new ConfirmTicketRepository();
+    tradeRepo = new ConfirmTradeRepository();
+    useCase = new ConfirmTradeUseCase(ticketRepo, tradeRepo, createLogger());
+
+    ticketRepo.ticket = new Ticket(1, BigInt(OWNER_ID), BigInt(2), BigInt(PARTNER_ID), TicketType.MM, TicketStatus.OPEN, new Date());
+    ticketRepo.participants = new Set([OWNER_ID, PARTNER_ID]);
+
+    const tradeA = new Trade(1, 1, BigInt(OWNER_ID), 'TraderA', null, TradeStatus.PENDING, false, [], new Date());
+    const tradeB = new Trade(2, 1, BigInt(PARTNER_ID), 'TraderB', null, TradeStatus.PENDING, false, [], new Date());
+    tradeRepo.trades = [tradeA, tradeB];
+  });
+
+  it('confirms ticket when both trades are confirmed', async () => {
+    const dto: ConfirmTradeDTO = { ticketId: 1, userId: OWNER_ID };
+
+    const result = await useCase.execute(dto);
+
+    expect(result.ticketConfirmed).toBe(false);
+    expect(tradeRepo.trades[0].confirmed).toBe(true);
+    expect(ticketRepo.ticket?.status).toBe(TicketStatus.OPEN);
+
+    const secondResult = await useCase.execute({ ticketId: 1, userId: PARTNER_ID });
+
+    expect(secondResult.ticketConfirmed).toBe(true);
+    expect(ticketRepo.ticket?.status).toBe(TicketStatus.CONFIRMED);
+    expect(ticketRepo.updated).toBe(true);
+  });
+
+  it('throws when user is not participant', async () => {
+    const dto: ConfirmTradeDTO = { ticketId: 1, userId: OTHER_ID };
+
+    await expect(useCase.execute(dto)).rejects.toThrow(UnauthorizedActionError);
+  });
+});

--- a/tests/unit/application/usecases/SubmitTradeDataUseCase.test.ts
+++ b/tests/unit/application/usecases/SubmitTradeDataUseCase.test.ts
@@ -1,0 +1,182 @@
+import type { Logger } from 'pino';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { SubmitTradeDataDTO } from '@/application/dto/trade.dto';
+import { SubmitTradeDataUseCase } from '@/application/usecases/middleman/SubmitTradeDataUseCase';
+import { Ticket } from '@/domain/entities/Ticket';
+import { Trade } from '@/domain/entities/Trade';
+import { TicketStatus, TicketType, type TradeItem } from '@/domain/entities/types';
+import type { ITicketRepository } from '@/domain/repositories/ITicketRepository';
+import type { ITradeRepository } from '@/domain/repositories/ITradeRepository';
+import { TradeStatus } from '@/domain/value-objects/TradeStatus';
+import { UnauthorizedActionError } from '@/shared/errors/domain.errors';
+
+class MockTicketRepository implements ITicketRepository {
+  public ticket: Ticket | null = null;
+  public participants = new Set<string>();
+
+  public withTransaction(): ITicketRepository {
+    return this;
+  }
+
+  public async create(): Promise<Ticket> {
+    throw new Error('not implemented');
+  }
+
+  public async findById(id: number): Promise<Ticket | null> {
+    if (!this.ticket || this.ticket.id !== id) {
+      return null;
+    }
+    return this.ticket;
+  }
+
+  public async findByChannelId(): Promise<Ticket | null> {
+    return null;
+  }
+
+  public async findOpenByOwner(): Promise<readonly Ticket[]> {
+    return [];
+  }
+
+  public async update(): Promise<void> {}
+
+  public async delete(): Promise<void> {}
+
+  public async countOpenByOwner(): Promise<number> {
+    return 0;
+  }
+
+  public async isParticipant(ticketId: number, userId: bigint): Promise<boolean> {
+    return this.ticket?.id === ticketId && this.participants.has(userId.toString());
+  }
+
+  public async listParticipants(): Promise<readonly { userId: bigint; role?: string | null; joinedAt?: Date }[]> {
+    return Array.from(this.participants).map((userId) => ({ userId: BigInt(userId) }));
+  }
+}
+
+class MockTradeRepository implements ITradeRepository {
+  public trades: Trade[] = [];
+  public updated = false;
+
+  public withTransaction(): ITradeRepository {
+    return this;
+  }
+
+  public async create(data: {
+    ticketId: number;
+    userId: bigint;
+    robloxUsername: string;
+    robloxUserId?: bigint | null;
+    status?: TradeStatus;
+    confirmed?: boolean;
+    items?: ReadonlyArray<TradeItem>;
+  }): Promise<Trade> {
+    const trade = new Trade(
+      this.trades.length + 1,
+      data.ticketId,
+      data.userId,
+      data.robloxUsername,
+      data.robloxUserId ?? null,
+      data.status ?? TradeStatus.PENDING,
+      data.confirmed ?? false,
+      data.items ? [...data.items] : [],
+      new Date(),
+    );
+    this.trades.push(trade);
+    return trade;
+  }
+
+  public async findById(): Promise<Trade | null> {
+    return null;
+  }
+
+  public async findByTicketId(ticketId: number): Promise<readonly Trade[]> {
+    return this.trades.filter((trade) => trade.ticketId === ticketId);
+  }
+
+  public async findByUserId(): Promise<readonly Trade[]> {
+    return [];
+  }
+
+  public async update(): Promise<void> {
+    this.updated = true;
+  }
+
+  public async delete(): Promise<void> {}
+}
+
+const createLogger = (): Logger =>
+  ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+    trace: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+    level: 'silent',
+  } as unknown as Logger);
+
+describe('SubmitTradeDataUseCase', () => {
+  const OWNER_ID = '111111111111111111';
+  const PARTNER_ID = '222222222222222222';
+  const OTHER_ID = '333333333333333333';
+  let ticketRepo: MockTicketRepository;
+  let tradeRepo: MockTradeRepository;
+  let useCase: SubmitTradeDataUseCase;
+
+  beforeEach(() => {
+    ticketRepo = new MockTicketRepository();
+    tradeRepo = new MockTradeRepository();
+    useCase = new SubmitTradeDataUseCase(ticketRepo, tradeRepo, createLogger());
+
+    ticketRepo.ticket = new Ticket(1, BigInt(OWNER_ID), BigInt(2), BigInt(PARTNER_ID), TicketType.MM, TicketStatus.OPEN, new Date());
+    ticketRepo.participants = new Set([OWNER_ID, PARTNER_ID]);
+  });
+
+  it('creates a new trade when participant submits data', async () => {
+    const dto: SubmitTradeDataDTO = {
+      ticketId: 1,
+      userId: PARTNER_ID,
+      robloxUsername: 'TraderOne',
+      offerDescription: 'Ofrezco 100k monedas',
+    };
+
+    const trade = await useCase.execute(dto);
+
+    expect(tradeRepo.trades).toHaveLength(1);
+    expect(trade.robloxUsername).toBe('TraderOne');
+    expect(trade.items).toHaveLength(1);
+    expect(trade.confirmed).toBe(false);
+  });
+
+  it('updates existing trade and resets confirmation', async () => {
+    const existing = new Trade(1, 1, BigInt(PARTNER_ID), 'OldName', null, TradeStatus.ACTIVE, true, [], new Date());
+    tradeRepo.trades = [existing];
+
+    const dto: SubmitTradeDataDTO = {
+      ticketId: 1,
+      userId: PARTNER_ID,
+      robloxUsername: 'UpdatedName',
+      offerDescription: 'Nuevo trato con detalles',
+    };
+
+    const trade = await useCase.execute(dto);
+
+    expect(trade.robloxUsername).toBe('UpdatedName');
+    expect(trade.confirmed).toBe(false);
+    expect(tradeRepo.updated).toBe(true);
+  });
+
+  it('throws when user is not participant', async () => {
+    const dto: SubmitTradeDataDTO = {
+      ticketId: 1,
+      userId: OTHER_ID,
+      robloxUsername: 'Intruso',
+      offerDescription: 'No debería funcionar',
+    };
+
+    await expect(useCase.execute(dto)).rejects.toThrow(UnauthorizedActionError);
+  });
+});

--- a/tests/unit/infrastructure/repositories/PrismaTradeRepository.test.ts
+++ b/tests/unit/infrastructure/repositories/PrismaTradeRepository.test.ts
@@ -1,0 +1,116 @@
+// ============================================================================
+// RUTA: tests/unit/infrastructure/repositories/PrismaTradeRepository.test.ts
+// ============================================================================
+
+import { Prisma, type PrismaClient } from '@prisma/client';
+import { describe, expect, it, vi } from 'vitest';
+
+import { Trade } from '@/domain/entities/Trade';
+import { TradeStatus } from '@/domain/value-objects/TradeStatus';
+import { PrismaTradeRepository } from '@/infrastructure/repositories/PrismaTradeRepository';
+
+const buildTrade = (items: Parameters<Trade['replaceItems']>[0]): Trade =>
+  new Trade(
+    42,
+    7,
+    BigInt('123456789012345678'),
+    'JohnDoe',
+    null,
+    TradeStatus.ACTIVE,
+    true,
+    items,
+    new Date('2024-01-01T00:00:00.000Z'),
+  );
+
+describe('PrismaTradeRepository.update', () => {
+  it('ejecuta la actualización dentro de una transacción cuando el cliente la soporta', async () => {
+    const innerUpdate = vi.fn(async () => {});
+    const innerDeleteMany = vi.fn(async () => {});
+    const innerCreateMany = vi.fn(async () => {});
+
+    const txStub = {
+      middlemanTrade: { update: innerUpdate },
+      middlemanTradeItem: { deleteMany: innerDeleteMany, createMany: innerCreateMany },
+    } satisfies Partial<Prisma.TransactionClient>;
+
+    const outerUpdate = vi.fn();
+    const outerDeleteMany = vi.fn();
+    const outerCreateMany = vi.fn();
+
+    const prismaClientMock = {
+      middlemanTrade: { update: outerUpdate },
+      middlemanTradeItem: { deleteMany: outerDeleteMany, createMany: outerCreateMany },
+      $transaction: vi.fn(async (callback: (tx: Prisma.TransactionClient) => Promise<void>) => {
+        await callback(txStub as Prisma.TransactionClient);
+      }),
+    };
+
+    const repository = new PrismaTradeRepository(prismaClientMock as unknown as PrismaClient);
+    const trade = buildTrade([
+      { name: 'Item A', quantity: 1, metadata: { description: 'Oferta A' } },
+      { name: 'Item B', quantity: 2, metadata: null },
+    ]);
+
+    await repository.update(trade);
+
+    expect(prismaClientMock.$transaction).toHaveBeenCalledTimes(1);
+    expect(innerUpdate).toHaveBeenCalledWith({
+      where: { id: trade.id },
+      data: {
+        status: trade.status,
+        confirmed: trade.confirmed,
+        robloxUserId: trade.robloxUserId,
+        robloxUsername: trade.robloxUsername,
+      },
+    });
+    expect(innerDeleteMany).toHaveBeenCalledWith({ where: { tradeId: trade.id } });
+    expect(innerCreateMany).toHaveBeenCalledWith({
+      data: [
+        {
+          tradeId: trade.id,
+          itemName: 'Item A',
+          quantity: 1,
+          metadata: { description: 'Oferta A' },
+        },
+        {
+          tradeId: trade.id,
+          itemName: 'Item B',
+          quantity: 2,
+          metadata: Prisma.JsonNull,
+        },
+      ],
+    });
+    expect(outerUpdate).not.toHaveBeenCalled();
+    expect(outerDeleteMany).not.toHaveBeenCalled();
+    expect(outerCreateMany).not.toHaveBeenCalled();
+  });
+
+  it('reutiliza el cliente transaccional cuando no se dispone de $transaction', async () => {
+    const update = vi.fn(async () => {});
+    const deleteMany = vi.fn(async () => {});
+    const createMany = vi.fn(async () => {});
+
+    const transactionClient = {
+      middlemanTrade: { update },
+      middlemanTradeItem: { deleteMany, createMany },
+    } as unknown as Prisma.TransactionClient;
+
+    const repository = new PrismaTradeRepository(transactionClient);
+    const trade = buildTrade([]);
+
+    await repository.update(trade);
+
+    expect(update).toHaveBeenCalledWith({
+      where: { id: trade.id },
+      data: {
+        status: trade.status,
+        confirmed: trade.confirmed,
+        robloxUserId: trade.robloxUserId,
+        robloxUsername: trade.robloxUsername,
+      },
+    });
+    expect(deleteMany).toHaveBeenCalledWith({ where: { tradeId: trade.id } });
+    expect(createMany).not.toHaveBeenCalled();
+  });
+});
+


### PR DESCRIPTION
## Summary
- update the Prisma trade repository to reuse the current transaction client when updating items
- ensure updates still run inside a Prisma transaction when available for atomic writes
- add unit tests covering both transactional paths of the trade repository update method

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dde97a613883268d60c1aa4212f75a