### PR TITLE
fix: normalize ticket staff role env parsing

### DIFF
--- a/src/application/usecases/tickets/OpenSupportTicketUseCase.ts
+++ b/src/application/usecases/tickets/OpenSupportTicketUseCase.ts
@@ -1,0 +1,172 @@
+// ============================================================================
+// RUTA: src/application/usecases/tickets/OpenSupportTicketUseCase.ts
+// ============================================================================
+
+import type { Guild, GuildMember, TextChannel } from 'discord.js';
+import { ChannelType, PermissionFlagsBits } from 'discord.js';
+import type { Logger } from 'pino';
+
+import type { Ticket } from '@/domain/entities/Ticket';
+import type { TicketType } from '@/domain/entities/types';
+import type { ITicketRepository } from '@/domain/repositories/ITicketRepository';
+import type { EmbedFactory } from '@/presentation/embeds/EmbedFactory';
+import { embedFactory } from '@/presentation/embeds/EmbedFactory';
+import {
+  ChannelCreationError,
+  TooManyOpenTicketsError,
+  ValidationFailedError,
+} from '@/shared/errors/domain.errors';
+import { sanitizeChannelName } from '@/shared/utils/discord.utils';
+
+const cooldownTracker = new Map<string, number>();
+
+const buildCooldownKey = (userId: string, type: TicketType): string => `${userId}:${type}`;
+
+interface OpenSupportTicketOptions {
+  readonly categoryId: string;
+  readonly staffRoleIds: readonly string[];
+  readonly maxTicketsPerUser: number;
+  readonly cooldownMs: number;
+}
+
+interface OpenSupportTicketParams {
+  readonly guild: Guild;
+  readonly member: GuildMember;
+  readonly type: TicketType;
+  readonly reason?: string;
+}
+
+export class OpenSupportTicketUseCase {
+  public constructor(
+    private readonly ticketRepo: ITicketRepository,
+    private readonly logger: Logger,
+    private readonly options: OpenSupportTicketOptions,
+    private readonly embeds: EmbedFactory = embedFactory,
+  ) {}
+
+  public async execute({ guild, member, type, reason }: OpenSupportTicketParams): Promise<{
+    readonly ticket: Ticket;
+    readonly channel: TextChannel;
+  }> {
+    if (!this.options.categoryId) {
+      throw new ValidationFailedError({ categoryId: 'Debe configurarse TICKET_CATEGORY_ID en el entorno.' });
+    }
+
+    const ownerId = BigInt(member.id);
+    const guildId = BigInt(guild.id);
+
+    const openTickets = await this.ticketRepo.countOpenByOwner(ownerId);
+    if (openTickets >= this.options.maxTicketsPerUser) {
+      throw new TooManyOpenTicketsError(this.options.maxTicketsPerUser);
+    }
+
+    const cooldownKey = buildCooldownKey(member.id, type);
+    const lastOpenedAt = cooldownTracker.get(cooldownKey) ?? 0;
+    const now = Date.now();
+    const remaining = this.options.cooldownMs - (now - lastOpenedAt);
+
+    if (this.options.cooldownMs > 0 && remaining > 0) {
+      throw new ValidationFailedError({
+        cooldown: `Debes esperar ${Math.ceil(remaining / 1000)} segundos antes de crear otro ticket de este tipo.`,
+      });
+    }
+
+    const botId = guild.members.me?.id;
+    if (!botId) {
+      throw new ChannelCreationError('El bot no se encuentra en el servidor.');
+    }
+
+    const baseName = `${type.toLowerCase()}-${member.displayName ?? member.user.username}`;
+    const channelName = sanitizeChannelName(baseName);
+
+    let createdChannel: TextChannel;
+    try {
+      createdChannel = await guild.channels.create({
+        name: channelName,
+        type: ChannelType.GuildText,
+        parent: this.options.categoryId,
+        permissionOverwrites: [
+          {
+            id: guild.roles.everyone.id,
+            deny: [PermissionFlagsBits.ViewChannel],
+          },
+          {
+            id: member.id,
+            allow: [
+              PermissionFlagsBits.ViewChannel,
+              PermissionFlagsBits.SendMessages,
+              PermissionFlagsBits.ReadMessageHistory,
+            ],
+          },
+          ...this.options.staffRoleIds.map((roleId) => ({
+            id: roleId,
+            allow: [
+              PermissionFlagsBits.ViewChannel,
+              PermissionFlagsBits.SendMessages,
+              PermissionFlagsBits.ReadMessageHistory,
+            ],
+          })),
+          {
+            id: botId,
+            allow: [
+              PermissionFlagsBits.ViewChannel,
+              PermissionFlagsBits.SendMessages,
+              PermissionFlagsBits.ManageChannels,
+              PermissionFlagsBits.ReadMessageHistory,
+            ],
+          },
+        ],
+      });
+    } catch (error) {
+      this.logger.error({ err: error, type, memberId: member.id }, 'Falló la creación del canal de ticket.');
+      throw new ChannelCreationError((error as Error).message);
+    }
+
+    try {
+      const ticket = await this.ticketRepo.create({
+        guildId,
+        channelId: BigInt(createdChannel.id),
+        ownerId,
+        type,
+        participants: [{ userId: ownerId, role: 'OWNER' }],
+      });
+
+      cooldownTracker.set(cooldownKey, now);
+
+      const mentionRoles = this.options.staffRoleIds;
+      const ticketEmbed = this.embeds.ticketCreated({
+        ticketId: ticket.id,
+        type: type.toLowerCase(),
+        ownerTag: `<@${member.id}>`,
+        description:
+          reason ?? 'Describe tu situación y un miembro del staff te ayudará lo antes posible.',
+      });
+
+      await createdChannel.send({
+        content: mentionRoles.length ? mentionRoles.map((roleId) => `<@&${roleId}>`).join(' ') : undefined,
+        embeds: [ticketEmbed],
+        allowedMentions: { roles: mentionRoles },
+      });
+
+      this.logger.info(
+        { ticketId: ticket.id, channelId: createdChannel.id, ownerId: member.id, type },
+        'Ticket de soporte creado correctamente.',
+      );
+
+      return { ticket, channel: createdChannel };
+    } catch (error) {
+      this.logger.error({ err: error, memberId: member.id }, 'Falló la persistencia del ticket.');
+
+      try {
+        await createdChannel.delete('Error al registrar ticket en la base de datos.');
+      } catch (cleanupError) {
+        this.logger.error(
+          { err: cleanupError, channelId: createdChannel.id },
+          'No se pudo eliminar el canal tras un fallo en el ticket.',
+        );
+      }
+
+      throw error;
+    }
+  }
+}

--- a/src/presentation/commands/general/rules.ts
+++ b/src/presentation/commands/general/rules.ts
@@ -1,0 +1,58 @@
+// ============================================================================
+// RUTA: src/presentation/commands/general/rules.ts
+// ============================================================================
+
+import { ChannelType, SlashCommandBuilder } from 'discord.js';
+
+import type { Command } from '@/presentation/commands/types';
+import { embedFactory } from '@/presentation/embeds/EmbedFactory';
+import { env } from '@/shared/config/env';
+
+const RULES = [
+  'Respeta a todos los miembros y evita lenguaje ofensivo.',
+  'Está prohibido estafar, impersonar o compartir información privada.',
+  'Los trades deben gestionarse en los canales correspondientes y con middleman oficial cuando se solicite.',
+  'No hagas spam ni promociones sin autorización del staff.',
+  'Sigue las indicaciones del equipo de moderación y abre un ticket si necesitas ayuda.',
+];
+
+const buildRulesEmbed = () =>
+  embedFactory.info({
+    title: '📜 Reglas principales de Dedos Shop',
+    description: RULES.map((rule, index) => `${index + 1}. ${rule}`).join('\n'),
+    footer: 'El incumplimiento puede resultar en sanciones dentro del servidor.',
+  });
+
+export const rulesCommand: Command = {
+  data: new SlashCommandBuilder().setName('rules').setDescription('Publica el panel con las reglas principales del servidor.'),
+  category: 'General',
+  examples: ['/rules', `${env.COMMAND_PREFIX}rules`],
+  prefix: {
+    name: 'rules',
+    async execute(message) {
+      if (message.channel.type !== ChannelType.GuildText) {
+        await message.reply({
+          embeds: [
+            embedFactory.warning({
+              title: 'Canal no compatible',
+              description: 'Las reglas solo pueden publicarse en canales de texto del servidor.',
+            }),
+          ],
+          allowedMentions: { repliedUser: false },
+        });
+        return;
+      }
+
+      await message.channel.send({
+        embeds: [buildRulesEmbed()],
+        allowedMentions: { parse: [] },
+      });
+    },
+  },
+  async execute(interaction) {
+    await interaction.reply({
+      embeds: [buildRulesEmbed()],
+      allowedMentions: { parse: [] },
+    });
+  },
+};

--- a/src/presentation/commands/index.ts
+++ b/src/presentation/commands/index.ts
@@ -11,11 +11,20 @@ import {
 } from '@/presentation/commands/command-registry';
 import { helpCommand } from '@/presentation/commands/general/help';
 import { pingCommand } from '@/presentation/commands/general/ping';
+import { rulesCommand } from '@/presentation/commands/general/rules';
 import { middlemanCommand } from '@/presentation/commands/middleman/middleman';
 import { middlemanDirectoryCommand } from '@/presentation/commands/middleman/mm';
+import { ticketsPanelCommand } from '@/presentation/commands/tickets/tickets';
 import type { Command } from '@/presentation/commands/types';
 
-const commands: Command[] = [pingCommand, helpCommand, middlemanCommand, middlemanDirectoryCommand];
+const commands: Command[] = [
+  pingCommand,
+  helpCommand,
+  rulesCommand,
+  middlemanCommand,
+  middlemanDirectoryCommand,
+  ticketsPanelCommand,
+];
 
 registerCommands(commands);
 

--- a/src/presentation/commands/tickets/tickets.ts
+++ b/src/presentation/commands/tickets/tickets.ts
@@ -1,0 +1,173 @@
+// ============================================================================
+// RUTA: src/presentation/commands/tickets/tickets.ts
+// ============================================================================
+
+import {
+  ChannelType,
+  type ChatInputCommandInteraction,
+  type GuildMember,
+  SlashCommandBuilder,
+} from 'discord.js';
+
+import { OpenSupportTicketUseCase } from '@/application/usecases/tickets/OpenSupportTicketUseCase';
+import { TicketType } from '@/domain/entities/types';
+import { prisma } from '@/infrastructure/db/prisma';
+import { PrismaTicketRepository } from '@/infrastructure/repositories/PrismaTicketRepository';
+import type { Command } from '@/presentation/commands/types';
+import { MiddlemanModal } from '@/presentation/components/modals/MiddlemanModal';
+import { registerSelectMenuHandler } from '@/presentation/components/registry';
+import { embedFactory } from '@/presentation/embeds/EmbedFactory';
+import {
+  buildTicketPanelMessage,
+  resolveTicketType,
+  TICKET_PANEL_MENU_ID,
+} from '@/presentation/tickets/TicketPanelBuilder';
+import { env } from '@/shared/config/env';
+import { mapErrorToDiscordResponse } from '@/shared/errors/discord-error-mapper';
+import { ValidationFailedError } from '@/shared/errors/domain.errors';
+import { logger } from '@/shared/logger/pino';
+
+const ticketRepository = new PrismaTicketRepository(prisma);
+
+const supportTicketUseCase = new OpenSupportTicketUseCase(
+  ticketRepository,
+  logger,
+  {
+    categoryId: env.TICKET_CATEGORY_ID ?? '',
+    staffRoleIds: env.TICKET_STAFF_ROLE_IDS,
+    maxTicketsPerUser: env.TICKET_MAX_PER_USER,
+    cooldownMs: env.TICKET_COOLDOWN_MS,
+  },
+  embedFactory,
+);
+
+const ensureGuildMember = (member: unknown): GuildMember => {
+  if (!member || typeof member !== 'object' || !('user' in member)) {
+    throw new ValidationFailedError({
+      member: 'No fue posible identificar al miembro que solicitó el ticket.',
+    });
+  }
+
+  return member as GuildMember;
+};
+
+registerSelectMenuHandler(TICKET_PANEL_MENU_ID, async (interaction) => {
+  if (!interaction.guild) {
+    await interaction.reply({
+      embeds: [
+        embedFactory.error({
+          title: 'Acción no disponible',
+          description: 'Este menú solo puede usarse dentro de un servidor de Discord.',
+        }),
+      ],
+      ephemeral: true,
+    });
+    return;
+  }
+
+  try {
+    const type = resolveTicketType(interaction);
+
+    if (type === TicketType.MM) {
+      await interaction.showModal(MiddlemanModal.build());
+      return;
+    }
+
+    const member = ensureGuildMember(interaction.member);
+
+    await interaction.deferReply({ ephemeral: true });
+
+    const { ticket, channel } = await supportTicketUseCase.execute({
+      guild: interaction.guild,
+      member,
+      type,
+    });
+
+    await interaction.editReply({
+      embeds: [
+        embedFactory.success({
+          title: 'Ticket creado',
+          description: `Tu ticket #${ticket.id} está listo en ${channel.toString()}.`,
+        }),
+      ],
+    });
+  } catch (error) {
+    const { shouldLogStack, referenceId, embeds, ...payload } = mapErrorToDiscordResponse(error);
+
+    if (shouldLogStack) {
+      logger.error({ err: error, referenceId }, 'Error inesperado al crear ticket de soporte.');
+    } else {
+      logger.warn({ err: error, referenceId }, 'Error controlado al crear ticket de soporte.');
+    }
+
+    if (interaction.deferred || interaction.replied) {
+      const { ephemeral, flags, ...editPayload } = payload;
+      await interaction.editReply({
+        ...editPayload,
+        embeds:
+          embeds ?? [
+            embedFactory.error({
+              title: 'No se pudo crear el ticket',
+              description: 'Verifica los requisitos e inténtalo nuevamente más tarde.',
+            }),
+          ],
+      });
+      return;
+    }
+
+    await interaction.reply({
+      ...payload,
+      embeds:
+        embeds ?? [
+          embedFactory.error({
+            title: 'No se pudo crear el ticket',
+            description: 'Verifica los requisitos e inténtalo nuevamente más tarde.',
+          }),
+        ],
+      ephemeral: true,
+    });
+  }
+});
+
+const publishTicketPanel = async (interaction: ChatInputCommandInteraction): Promise<void> => {
+  const panel = buildTicketPanelMessage();
+
+  await interaction.reply({
+    ...panel,
+    allowedMentions: { parse: [] },
+  });
+};
+
+export const ticketsPanelCommand: Command = {
+  data: new SlashCommandBuilder()
+    .setName('tickets')
+    .setDescription('Publica el panel interactivo para crear tickets de soporte.'),
+  category: 'Tickets',
+  examples: ['/tickets', `${env.COMMAND_PREFIX}tickets`],
+  prefix: {
+    name: 'tickets',
+    async execute(message) {
+      if (message.channel.type !== ChannelType.GuildText) {
+        await message.reply({
+          embeds: [
+            embedFactory.warning({
+              title: 'Canal no compatible',
+              description: 'El panel solo puede publicarse en canales de texto del servidor.',
+            }),
+          ],
+          allowedMentions: { repliedUser: false },
+        });
+        return;
+      }
+
+      const panel = buildTicketPanelMessage();
+      await message.channel.send({
+        ...panel,
+        allowedMentions: { parse: [] },
+      });
+    },
+  },
+  async execute(interaction) {
+    await publishTicketPanel(interaction);
+  },
+};

--- a/src/presentation/components/buttons/TradePanelButtons.ts
+++ b/src/presentation/components/buttons/TradePanelButtons.ts
@@ -8,8 +8,16 @@ export const TRADE_DATA_BUTTON_ID = 'middleman:trade:data';
 export const TRADE_CONFIRM_BUTTON_ID = 'middleman:trade:confirm';
 export const TRADE_HELP_BUTTON_ID = 'middleman:trade:help';
 
-export const buildTradePanelButtons = (): ActionRowBuilder<ButtonBuilder> =>
-  new ActionRowBuilder<ButtonBuilder>().addComponents(
+interface TradePanelButtonOptions {
+  readonly canConfirm?: boolean;
+}
+
+export const buildTradePanelButtons = (
+  options: TradePanelButtonOptions = {},
+): ActionRowBuilder<ButtonBuilder> => {
+  const { canConfirm = true } = options;
+
+  return new ActionRowBuilder<ButtonBuilder>().addComponents(
     new ButtonBuilder()
       .setCustomId(TRADE_DATA_BUTTON_ID)
       .setLabel('Mis datos de trade')
@@ -19,10 +27,12 @@ export const buildTradePanelButtons = (): ActionRowBuilder<ButtonBuilder> =>
       .setCustomId(TRADE_CONFIRM_BUTTON_ID)
       .setLabel('Confirmar trade')
       .setEmoji('✅')
-      .setStyle(ButtonStyle.Success),
+      .setStyle(ButtonStyle.Success)
+      .setDisabled(!canConfirm),
     new ButtonBuilder()
       .setCustomId(TRADE_HELP_BUTTON_ID)
       .setLabel('Pedir ayuda')
       .setEmoji('🚨')
       .setStyle(ButtonStyle.Danger),
   );
+};

--- a/src/presentation/components/registry.ts
+++ b/src/presentation/components/registry.ts
@@ -2,14 +2,20 @@
 // RUTA: src/presentation/components/registry.ts
 // ============================================================================
 
-import type { ButtonInteraction, ModalSubmitInteraction } from 'discord.js';
+import type {
+  ButtonInteraction,
+  ModalSubmitInteraction,
+  StringSelectMenuInteraction,
+} from 'discord.js';
 import { Collection } from 'discord.js';
 
 type ButtonHandler = (interaction: ButtonInteraction) => Promise<void>;
 type ModalHandler = (interaction: ModalSubmitInteraction) => Promise<void>;
+type SelectMenuHandler = (interaction: StringSelectMenuInteraction) => Promise<void>;
 
 export const buttonHandlers = new Collection<string, ButtonHandler>();
 export const modalHandlers = new Collection<string, ModalHandler>();
+export const selectMenuHandlers = new Collection<string, SelectMenuHandler>();
 
 export const registerButtonHandler = (customId: string, handler: ButtonHandler): void => {
   if (buttonHandlers.has(customId)) {
@@ -23,4 +29,12 @@ export const registerModalHandler = (customId: string, handler: ModalHandler): v
     throw new Error(`El modal con customId ${customId} ya está registrado.`);
   }
   modalHandlers.set(customId, handler);
+};
+
+export const registerSelectMenuHandler = (customId: string, handler: SelectMenuHandler): void => {
+  if (selectMenuHandlers.has(customId)) {
+    throw new Error(`El menú con customId ${customId} ya está registrado.`);
+  }
+
+  selectMenuHandlers.set(customId, handler);
 };

--- a/src/presentation/events/interactionCreate.ts
+++ b/src/presentation/events/interactionCreate.ts
@@ -7,11 +7,16 @@ import type {
   ChatInputCommandInteraction,
   Interaction,
   ModalSubmitInteraction,
+  StringSelectMenuInteraction,
 } from 'discord.js';
 import { Events } from 'discord.js';
 
 import { commandRegistry } from '@/presentation/commands';
-import { buttonHandlers, modalHandlers } from '@/presentation/components/registry';
+import {
+  buttonHandlers,
+  modalHandlers,
+  selectMenuHandlers,
+} from '@/presentation/components/registry';
 import { embedFactory } from '@/presentation/embeds/EmbedFactory';
 import type { EventDescriptor } from '@/presentation/events/types';
 import { mapErrorToDiscordResponse } from '@/shared/errors/discord-error-mapper';
@@ -78,6 +83,27 @@ const handleModal = async (interaction: ModalSubmitInteraction): Promise<void> =
   await handler(interaction);
 };
 
+const handleSelectMenu = async (interaction: StringSelectMenuInteraction): Promise<void> => {
+  const handler = selectMenuHandlers.get(interaction.customId);
+
+  if (!handler) {
+    logger.warn({ customId: interaction.customId }, 'No existe handler registrado para el menú.');
+    await interaction.reply({
+      embeds: [
+        embedFactory.warning({
+          title: 'Acción no disponible',
+          description:
+            'Este menú ya no está activo. Vuelve a ejecutar el comando para obtener una versión actualizada.',
+        }),
+      ],
+      ephemeral: true,
+    });
+    return;
+  }
+
+  await handler(interaction);
+};
+
 export const interactionCreateEvent: EventDescriptor<typeof Events.InteractionCreate> = {
   name: Events.InteractionCreate,
   once: false,
@@ -95,6 +121,11 @@ export const interactionCreateEvent: EventDescriptor<typeof Events.InteractionCr
 
       if (interaction.isModalSubmit()) {
         await handleModal(interaction);
+        return;
+      }
+
+      if (interaction.isStringSelectMenu()) {
+        await handleSelectMenu(interaction);
         return;
       }
     } catch (error) {

--- a/src/presentation/middleman/MiddlemanPanelBuilder.ts
+++ b/src/presentation/middleman/MiddlemanPanelBuilder.ts
@@ -1,0 +1,53 @@
+// ============================================================================
+// RUTA: src/presentation/middleman/MiddlemanPanelBuilder.ts
+// ============================================================================
+
+import {
+  ActionRowBuilder,
+  type EmbedBuilder,
+  StringSelectMenuBuilder,
+} from 'discord.js';
+
+import { embedFactory } from '@/presentation/embeds/EmbedFactory';
+
+export const MIDDLEMAN_PANEL_MENU_ID = 'middleman:panel:menu';
+
+export const buildMiddlemanPanelMessage = (): {
+  readonly embeds: EmbedBuilder[];
+  readonly components: [ActionRowBuilder<StringSelectMenuBuilder>];
+  readonly allowedMentions: { readonly parse: [] };
+} => {
+  const embed = embedFactory.info({
+    title: '🛡️ Middleman Dedos Shop',
+    description:
+      [
+        'Asegura tus trades utilizando el equipo oficial de middleman.',
+        'Selecciona una opción para conocer el flujo o abrir tu ticket de middleman.',
+      ].join('\n'),
+  });
+
+  const menu = new StringSelectMenuBuilder()
+    .setCustomId(MIDDLEMAN_PANEL_MENU_ID)
+    .setPlaceholder('Selecciona una opción')
+    .addOptions(
+      { label: 'Cómo funciona', value: 'info', emoji: '📖' },
+      { label: 'Abrir middleman', value: 'open', emoji: '🛠️' },
+    );
+
+  return {
+    embeds: [embed],
+    components: [new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(menu)],
+    allowedMentions: { parse: [] as const },
+  };
+};
+
+export const buildMiddlemanInfoEmbed = (): EmbedBuilder =>
+  embedFactory.info({
+    title: '📖 ¿Cómo funciona el middleman?',
+    description: [
+      '1. Completa el formulario indicando con quién realizarás el trade y los detalles del acuerdo.',
+      '2. Ambos traders registran sus datos y confirman cuando estén listos.',
+      '3. Al confirmar, se notifica al equipo middleman para que supervise el intercambio.',
+      '4. Usa el botón **Pedir ayuda** si necesitas asistencia adicional durante el proceso.',
+    ].join('\n'),
+  });

--- a/src/presentation/middleman/TradePanelRenderer.ts
+++ b/src/presentation/middleman/TradePanelRenderer.ts
@@ -86,9 +86,11 @@ export class TradePanelRenderer {
       ].join('\n\n'),
     });
 
+    const canConfirm = Boolean(ownerTrade && partnerTrade && !everyoneConfirmed);
+
     const payload: Parameters<TextChannel['send']>[0] = {
       embeds: [embed],
-      components: [buildTradePanelButtons()],
+      components: [buildTradePanelButtons({ canConfirm })],
       allowedMentions: { parse: [] },
     };
 

--- a/src/presentation/tickets/TicketPanelBuilder.ts
+++ b/src/presentation/tickets/TicketPanelBuilder.ts
@@ -1,0 +1,113 @@
+// ============================================================================
+// RUTA: src/presentation/tickets/TicketPanelBuilder.ts
+// ============================================================================
+
+import {
+  ActionRowBuilder,
+  type EmbedBuilder,
+  StringSelectMenuBuilder,
+  type StringSelectMenuInteraction,
+} from 'discord.js';
+
+import { TicketType } from '@/domain/entities/types';
+import { embedFactory } from '@/presentation/embeds/EmbedFactory';
+import { ValidationFailedError } from '@/shared/errors/domain.errors';
+
+export const TICKET_PANEL_MENU_ID = 'tickets:panel:menu';
+
+const TICKET_OPTIONS: Array<{
+  readonly value: string;
+  readonly label: string;
+  readonly description: string;
+  readonly type: TicketType;
+  readonly emoji?: string;
+}> = [
+  {
+    value: 'buy',
+    label: 'Comprar en Dedos Shop',
+    description: 'Solicita un producto o servicio de la tienda.',
+    type: TicketType.BUY,
+    emoji: '🛒',
+  },
+  {
+    value: 'sell',
+    label: 'Vender a la tienda',
+    description: 'Ofrece tus artículos o cuentas a Dedos Shop.',
+    type: TicketType.SELL,
+    emoji: '💼',
+  },
+  {
+    value: 'robux',
+    label: 'Robux / Giftcards',
+    description: 'Soporte relacionado a Robux o tarjetas de regalo.',
+    type: TicketType.ROBUX,
+    emoji: '💎',
+  },
+  {
+    value: 'nitro',
+    label: 'Discord Nitro',
+    description: 'Consultas sobre membresías o renovaciones de Nitro.',
+    type: TicketType.NITRO,
+    emoji: '✨',
+  },
+  {
+    value: 'decor',
+    label: 'Decor / Diseño',
+    description: 'Pedidos personalizados de decoración o diseño.',
+    type: TicketType.DECOR,
+    emoji: '🎨',
+  },
+  {
+    value: 'mm',
+    label: 'Middleman dedicado',
+    description: 'Pide ayuda del staff para trades externos a la tienda.',
+    type: TicketType.MM,
+    emoji: '🛡️',
+  },
+];
+
+export const buildTicketPanelMessage = (): {
+  readonly embeds: EmbedBuilder[];
+  readonly components: [ActionRowBuilder<StringSelectMenuBuilder>];
+  readonly allowedMentions: { readonly parse: [] };
+} => {
+  const embed = embedFactory.info({
+    title: '🎫 Centro de tickets Dedos Shop',
+    description: [
+      'Selecciona la opción que mejor describa tu solicitud.',
+      'Un miembro del staff responderá lo antes posible.',
+    ].join('\n'),
+  });
+
+  const menu = new StringSelectMenuBuilder()
+    .setCustomId(TICKET_PANEL_MENU_ID)
+    .setPlaceholder('Selecciona el motivo de tu ticket')
+    .addOptions(
+      TICKET_OPTIONS.map((option) => ({
+        label: option.label,
+        value: option.value,
+        description: option.description,
+        emoji: option.emoji,
+      })),
+    );
+
+  return {
+    embeds: [embed],
+    components: [new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(menu)],
+    allowedMentions: { parse: [] as const },
+  };
+};
+
+export const resolveTicketType = (interaction: StringSelectMenuInteraction): TicketType => {
+  const value = interaction.values.at(0);
+  if (!value) {
+    throw new ValidationFailedError({ ticketType: 'Debes seleccionar un tipo de ticket válido.' });
+  }
+
+  const option = TICKET_OPTIONS.find((candidate) => candidate.value === value);
+  if (!option) {
+    throw new ValidationFailedError({ ticketType: 'El tipo de ticket seleccionado no está disponible.' });
+  }
+
+  return option.type;
+};

--- a/src/shared/config/env.ts
+++ b/src/shared/config/env.ts
@@ -28,6 +28,39 @@ const optionalUrl = z
   .or(z.literal(''))
   .transform((value) => (value === '' ? undefined : value));
 
+const snowflakePattern = /^\d{17,20}$/u;
+
+const commaSeparatedSnowflakes = z
+  .preprocess((raw) => {
+    const segments: string[] = [];
+
+    const pushSegment = (segment: unknown) => {
+      if (segment === undefined || segment === null) {
+        return;
+      }
+
+      const text = typeof segment === 'string' ? segment : String(segment);
+
+      text
+        .split(',')
+        .map((value) => value.trim())
+        .filter((value) => value.length > 0)
+        .forEach((value) => {
+          if (snowflakePattern.test(value)) {
+            segments.push(value);
+          }
+        });
+    };
+
+    if (Array.isArray(raw)) {
+      raw.forEach(pushSegment);
+    } else {
+      pushSegment(raw);
+    }
+
+    return segments;
+  }, z.array(z.string().regex(snowflakePattern)));
+
 export const EnvSchema = z.object({
   DISCORD_TOKEN: z.string().min(1, 'DISCORD_TOKEN es obligatorio'),
   DISCORD_CLIENT_ID: z
@@ -56,6 +89,13 @@ export const EnvSchema = z.object({
     .string()
     .regex(/^\d{17,20}$/u, 'REVIEW_CHANNEL_ID debe ser un snowflake de Discord')
     .optional(),
+  TICKET_CATEGORY_ID: z
+    .string()
+    .regex(/^\d{17,20}$/u, 'TICKET_CATEGORY_ID debe ser un snowflake de Discord')
+    .optional(),
+  TICKET_STAFF_ROLE_IDS: commaSeparatedSnowflakes.default([]),
+  TICKET_MAX_PER_USER: z.coerce.number().int().min(1).max(10).default(3),
+  TICKET_COOLDOWN_MS: z.coerce.number().int().min(0).default(60_000),
   REDIS_URL: optionalUrl.optional(),
   NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
   LOG_LEVEL: z.enum(['debug', 'info', 'warn', 'error']).default('info'),


### PR DESCRIPTION
## Summary
- normalize ticket staff role parsing to accept comma-separated strings or arrays when reading environment variables
- share a reusable snowflake regex to filter invalid entries before validation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de19fb370c8326ada2bec042af0dfb