### PR TITLE
fix: align middleman validation and log version info

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dedos-shop-bot",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dedos-shop-bot",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@discordjs/rest": "^2.3.0",
         "@prisma/client": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dedos-shop-bot",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Discord bot for Dedos Shop with a clean TypeScript architecture and Prisma-backed persistence.",
   "type": "module",
   "main": "dist/index.js",

--- a/qarchivo.md
+++ b/qarchivo.md
@@ -1,0 +1,19 @@
+# QArchivo - Registro de Cambios
+
+## Versión 1.0.1
+- **Fecha de creación:** 2025-10-02T07:00:46+00:00
+- **Flujo actualizado:** se alinea el proceso de tickets middleman con la rama `codex/fix-errors-in-middleman-logic`, validando menciones de compañeros y renderizando el panel de trade con los datos registrados.
+- **Modificaciones clave:**
+  - Se acepta cualquier formato válido de mención o ID de Discord al abrir un ticket y se evita el rechazo por validar solo números.
+  - El panel de confirmación muestra el resumen del trade (Roblox, oferta y estado de confirmación) para cada participante incluso cuando la información está pendiente.
+  - El bot imprime en consola la versión activa y la fecha exacta de inicio para llevar control de versiones.
+- **Recordatorio:** cada cambio registrado en este archivo representa una nueva versión del proyecto. Mantén el flujo documentado en cada iteración.
+
+### Detalle del flujo
+1. El usuario abre el ticket de middleman e introduce la descripción y el compañero utilizando mención o ID. La validación admite ambos formatos.
+2. El bot crea el canal, publica el panel y, al registrar datos del trade, actualiza el resumen mostrando Roblox, oferta y confirmación dentro del mismo embed.
+3. Al iniciar el bot se informa la versión `1.0.1`, el momento exacto de arranque y se recuerda que cada modificación implica una nueva versión controlada.
+
+### Notas técnicas
+- El número de versión del proyecto se incrementó a `1.0.1`.
+- Se puede reutilizar esta plantilla para registrar futuras versiones, asegurando que la fecha incluya segundos para trazabilidad.

--- a/src/application/dto/ticket.dto.ts
+++ b/src/application/dto/ticket.dto.ts
@@ -11,7 +11,8 @@ export const CreateMiddlemanTicketSchema = z.object({
   context: z.string().min(10).max(1000, 'Context must be 10-1000 chars'),
   partnerTag: z
     .string()
-    .regex(/\d{17,20}/u, 'Debe proporcionar la mención o ID del compañero'),
+    .trim()
+    .regex(/^(?:<@!?(\d{17,20})>|\d{17,20})$/u, 'Debe proporcionar la mención o ID del compañero'),
   categoryId: z.string().regex(/^\d+$/u, 'Invalid category ID'),
   robloxUsername: z.string().min(3).max(50).optional(),
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { commandRegistry } from '@/presentation/commands';
 import { type AnyEventDescriptor, events } from '@/presentation/events';
 import { env } from '@/shared/config/env';
 import { logger } from '@/shared/logger/pino';
+import { versionInfo } from '@/shared/version';
 
 const client = new Client({
   intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages, GatewayIntentBits.MessageContent],
@@ -37,7 +38,11 @@ const registerEvent = (descriptor: AnyEventDescriptor): void => {
 };
 
 const bootstrap = async (): Promise<void> => {
-  logger.info({ env: env.NODE_ENV }, 'Iniciando Dedos Bot...');
+  logger.info({
+    env: env.NODE_ENV,
+    version: versionInfo.version,
+    startedAt: versionInfo.startedAtIso,
+  }, 'Iniciando Dedos Bot. Cada cambio corresponde a una nueva versión.');
 
   await ensureDatabaseConnection();
 

--- a/src/presentation/middleman/TradePanelRenderer.ts
+++ b/src/presentation/middleman/TradePanelRenderer.ts
@@ -21,20 +21,22 @@ const hasDescriptionMetadata = (
 
 const formatTradeSummary = (trade: Trade | undefined): string => {
   if (!trade) {
-    return '• Datos: ❌ Sin registrar\n• Confirmación: ⏳ Pendiente';
+    return [
+      '• Roblox: ❌ Sin registrar',
+      '• Oferta: ❌ Sin registrar',
+      '• Confirmación: ⏳ Pendiente',
+    ].join('\n');
   }
 
   const metadata = trade.items[0]?.metadata;
   const rawDescription = hasDescriptionMetadata(metadata) ? metadata.description : null;
-  const description = typeof rawDescription === 'string' ? rawDescription : null;
+  const description = typeof rawDescription === 'string' ? rawDescription.trim() : null;
 
   return [
     `• Roblox: **${trade.robloxUsername}**`,
-    description ? `• Oferta: ${String(description)}` : null,
+    description ? `• Oferta: ${description}` : '• Oferta: ❌ Sin registrar',
     `• Confirmación: ${trade.confirmed ? '✅ Registrada' : '⏳ Pendiente'}`,
-  ]
-    .filter(Boolean)
-    .join('\n');
+  ].join('\n');
 };
 
 const resolvePartnerId = (

--- a/src/shared/version.ts
+++ b/src/shared/version.ts
@@ -1,0 +1,19 @@
+// ============================================================================
+// RUTA: src/shared/version.ts
+// ============================================================================
+
+import packageJson from '../../package.json' assert { type: 'json' };
+
+type PackageJson = {
+  readonly version?: string;
+};
+
+const { version = '0.0.0' } = packageJson as PackageJson;
+const startupTimestamp = new Date();
+
+export const versionInfo = {
+  version,
+  startedAt: startupTimestamp,
+  startedAtIso: startupTimestamp.toISOString(),
+  reminder: 'Cada cambio documentado corresponde a una nueva versión del proyecto.',
+} as const;


### PR DESCRIPTION
## Summary
- allow Discord mentions or raw IDs when opening middleman tickets and document the release in `qarchivo.md`
- show each participant's Roblox, offer, and confirmation status inside the middleman panel so trade data lives in the confirmation flow
- log the project version and startup timestamp on boot via the new shared version helper

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68de22b2fe00832681803e590c65c04d