### PR TITLE
Fix middleman partner validation and replace deprecated ephemeral responses

### DIFF
--- a/src/application/dto/ticket.dto.ts
+++ b/src/application/dto/ticket.dto.ts
@@ -12,7 +12,7 @@ export const CreateMiddlemanTicketSchema = z.object({
   partnerTag: z
     .string()
     .trim()
-    .regex(/^(?:<@!?(\d{17,20})>|\d{17,20})$/u, 'Debe proporcionar la mención o ID del compañero'),
+    .regex(/^(?:<@!?(\d{17,20})>|\d{17,20})$/u, 'Debe proporcionar la mencion o ID del companero'),
   categoryId: z.string().regex(/^\d+$/u, 'Invalid category ID'),
   robloxUsername: z.string().min(3).max(50).optional(),
 });

--- a/src/application/usecases/middleman/OpenMiddlemanChannelUseCase.ts
+++ b/src/application/usecases/middleman/OpenMiddlemanChannelUseCase.ts
@@ -74,7 +74,7 @@ export class OpenMiddlemanChannelUseCase {
 
     if (!partnerId) {
       throw new ValidationFailedError({
-        partnerTag: 'Debes mencionar o introducir el ID de la persona con la que harás el trade.',
+        partnerTag: 'Debes mencionar o introducir el ID de la persona con la que haras el trade.',
       });
     }
 

--- a/src/presentation/commands/general/help.ts
+++ b/src/presentation/commands/general/help.ts
@@ -2,7 +2,7 @@
 // RUTA: src/presentation/commands/general/help.ts
 // ============================================================================
 
-import { SlashCommandBuilder } from 'discord.js';
+import { MessageFlags, SlashCommandBuilder } from 'discord.js';
 
 import { getRegisteredCommands } from '@/presentation/commands/command-registry';
 import type { Command } from '@/presentation/commands/types';
@@ -42,7 +42,7 @@ export const helpCommand: Command = {
   async execute(interaction) {
     await interaction.reply({
       embeds: [createHelpEmbed()],
-      ephemeral: true,
+      flags: MessageFlags.Ephemeral,
     });
   },
 };

--- a/src/presentation/commands/general/ping.ts
+++ b/src/presentation/commands/general/ping.ts
@@ -2,7 +2,7 @@
 // RUTA: src/presentation/commands/general/ping.ts
 // ============================================================================
 
-import { SlashCommandBuilder } from 'discord.js';
+import { MessageFlags, SlashCommandBuilder } from 'discord.js';
 
 import type { Command } from '@/presentation/commands/types';
 import { embedFactory } from '@/presentation/embeds/EmbedFactory';
@@ -51,7 +51,7 @@ export const pingCommand: Command = {
           footer: `Próxima actualización disponible en ${COOLDOWNS.ping / 1000}s`,
         }),
       ],
-      ephemeral: true,
+      flags: MessageFlags.Ephemeral,
     });
   },
 };

--- a/src/presentation/commands/middleman/middleman.ts
+++ b/src/presentation/commands/middleman/middleman.ts
@@ -2,7 +2,8 @@
 // RUTA: src/presentation/commands/middleman/middleman.ts
 // ============================================================================
 
-import { ChannelType, type ChatInputCommandInteraction, SlashCommandBuilder, type TextChannel } from 'discord.js';
+import type { ChatInputCommandInteraction, TextChannel } from 'discord.js';
+import { ChannelType, MessageFlags, SlashCommandBuilder } from 'discord.js';
 
 import { reviewInviteStore } from '@/application/services/ReviewInviteStore';
 import { ClaimTradeUseCase } from '@/application/usecases/middleman/ClaimTradeUseCase';
@@ -78,7 +79,7 @@ registerModalHandler(TradeModal.CUSTOM_ID, async (interaction) => {
           description: 'Este formulario solo puede utilizarse dentro de un canal de texto.',
         }),
       ],
-      ephemeral: true,
+      flags: MessageFlags.Ephemeral,
     });
     return;
   }
@@ -108,7 +109,7 @@ registerModalHandler(TradeModal.CUSTOM_ID, async (interaction) => {
           description: 'Tu información del trade se actualizó correctamente.',
         }),
       ],
-      ephemeral: true,
+      flags: MessageFlags.Ephemeral,
     });
   } catch (error) {
     const { shouldLogStack, referenceId, embeds, ...payload } = mapErrorToDiscordResponse(error);
@@ -120,7 +121,7 @@ registerModalHandler(TradeModal.CUSTOM_ID, async (interaction) => {
     }
 
     if (interaction.deferred || interaction.replied) {
-      const { ephemeral, flags, ...editPayload } = payload;
+      const { flags, ...editPayload } = payload;
       await interaction.editReply({
         ...editPayload,
         embeds:
@@ -143,7 +144,7 @@ registerModalHandler(TradeModal.CUSTOM_ID, async (interaction) => {
             description: 'Inténtalo nuevamente más tarde o contacta al staff.',
           }),
         ],
-      ephemeral: true,
+      flags: MessageFlags.Ephemeral,
     });
   }
 });
@@ -159,7 +160,7 @@ registerButtonHandler(REVIEW_BUTTON_CUSTOM_ID, async (interaction) => {
           description: 'Esta invitación de reseña ha expirado. Solicita al staff que envíe una nueva.',
         }),
       ],
-      ephemeral: true,
+      flags: MessageFlags.Ephemeral,
     });
     return;
   }
@@ -173,7 +174,7 @@ registerButtonHandler(REVIEW_BUTTON_CUSTOM_ID, async (interaction) => {
           description: 'Solo los participantes del ticket pueden enviar una reseña.',
         }),
       ],
-      ephemeral: true,
+      flags: MessageFlags.Ephemeral,
     });
     return;
   }
@@ -197,7 +198,7 @@ registerButtonHandler(REVIEW_BUTTON_CUSTOM_ID, async (interaction) => {
                 'No se pudo encontrar el canal de reseñas. Un administrador debe establecer `REVIEW_CHANNEL_ID` en el .env.',
             }),
           ],
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
         return;
       }
@@ -212,7 +213,7 @@ registerButtonHandler(REVIEW_BUTTON_CUSTOM_ID, async (interaction) => {
               description: 'El canal de reseñas configurado no es un canal de texto válido.',
             }),
           ],
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
         return;
       }
@@ -235,7 +236,7 @@ registerButtonHandler(REVIEW_BUTTON_CUSTOM_ID, async (interaction) => {
             description: 'Tu valoración se ha publicado correctamente en el canal de reseñas.',
           }),
         ],
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
       });
     } catch (error) {
       const { shouldLogStack, referenceId, embeds, ...payload } = mapErrorToDiscordResponse(error);
@@ -255,7 +256,7 @@ registerButtonHandler(REVIEW_BUTTON_CUSTOM_ID, async (interaction) => {
               description: 'Ocurrió un error al procesar tu reseña. Inténtalo nuevamente en unos minutos.',
             }),
           ],
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
       });
     } finally {
       modalHandlers.delete(modalCustomId);
@@ -274,7 +275,7 @@ registerButtonHandler(TRADE_DATA_BUTTON_ID, async (interaction) => {
           description: 'Este botón solo funciona dentro de un canal de trade.',
         }),
       ],
-      ephemeral: true,
+      flags: MessageFlags.Ephemeral,
     });
     return;
   }
@@ -293,7 +294,7 @@ registerButtonHandler(TRADE_CONFIRM_BUTTON_ID, async (interaction) => {
           description: 'Este botón solo funciona dentro de un canal de trade.',
         }),
       ],
-      ephemeral: true,
+      flags: MessageFlags.Ephemeral,
     });
     return;
   }
@@ -319,7 +320,7 @@ registerButtonHandler(TRADE_CONFIRM_BUTTON_ID, async (interaction) => {
           description: 'Tu confirmación quedó registrada correctamente.',
         }),
       ],
-      ephemeral: true,
+      flags: MessageFlags.Ephemeral,
     });
 
     if (result.ticketConfirmed) {
@@ -339,7 +340,7 @@ registerButtonHandler(TRADE_CONFIRM_BUTTON_ID, async (interaction) => {
     }
 
     if (interaction.deferred || interaction.replied) {
-      const { ephemeral, flags, ...editPayload } = payload;
+      const { flags, ...editPayload } = payload;
       await interaction.editReply({
         ...editPayload,
         embeds:
@@ -362,7 +363,7 @@ registerButtonHandler(TRADE_CONFIRM_BUTTON_ID, async (interaction) => {
             description: 'Inténtalo nuevamente o contacta al staff.',
           }),
         ],
-      ephemeral: true,
+      flags: MessageFlags.Ephemeral,
     });
   }
 });
@@ -376,7 +377,7 @@ registerButtonHandler(TRADE_HELP_BUTTON_ID, async (interaction) => {
           description: 'Este botón solo funciona dentro de un canal de trade.',
         }),
       ],
-      ephemeral: true,
+      flags: MessageFlags.Ephemeral,
     });
     return;
   }
@@ -388,7 +389,7 @@ registerButtonHandler(TRADE_HELP_BUTTON_ID, async (interaction) => {
         description: 'Se notificó al equipo middleman. Por favor, espera en el canal.',
       }),
     ],
-    ephemeral: true,
+    flags: MessageFlags.Ephemeral,
   });
 
   const mention = env.MIDDLEMAN_ROLE_ID ? `<@&${env.MIDDLEMAN_ROLE_ID}>` : 'Equipo middleman';
@@ -407,7 +408,7 @@ registerSelectMenuHandler(MIDDLEMAN_PANEL_MENU_ID, async (interaction) => {
           description: 'Este menú solo puede utilizarse dentro de un servidor.',
         }),
       ],
-      ephemeral: true,
+      flags: MessageFlags.Ephemeral,
     });
     return;
   }
@@ -417,7 +418,7 @@ registerSelectMenuHandler(MIDDLEMAN_PANEL_MENU_ID, async (interaction) => {
   if (value === 'info') {
     await interaction.reply({
       embeds: [buildMiddlemanInfoEmbed()],
-      ephemeral: true,
+      flags: MessageFlags.Ephemeral,
     });
     return;
   }
@@ -434,7 +435,7 @@ registerSelectMenuHandler(MIDDLEMAN_PANEL_MENU_ID, async (interaction) => {
         description: 'Selecciona una opción válida del menú para continuar.',
       }),
     ],
-    ephemeral: true,
+    flags: MessageFlags.Ephemeral,
   });
 });
 
@@ -461,7 +462,7 @@ const handleOpen = async (interaction: ChatInputCommandInteraction): Promise<voi
           description: 'Este comando solo puede utilizarse dentro de un servidor.',
         }),
       ],
-      ephemeral: true,
+      flags: MessageFlags.Ephemeral,
     });
     return;
   }
@@ -486,7 +487,7 @@ const handleClaim = async (interaction: ChatInputCommandInteraction): Promise<vo
     throw new TicketNotFoundError(channel.id);
   }
 
-  await interaction.deferReply({ ephemeral: true });
+  await interaction.deferReply({ flags: MessageFlags.Ephemeral });
   await claimUseCase.execute({ ticketId: ticket.id, middlemanId: interaction.user.id }, channel);
 
   await interaction.editReply({
@@ -507,7 +508,7 @@ const handleClose = async (interaction: ChatInputCommandInteraction): Promise<vo
     throw new TicketNotFoundError(channel.id);
   }
 
-  await interaction.deferReply({ ephemeral: true });
+  await interaction.deferReply({ flags: MessageFlags.Ephemeral });
   await closeUseCase.execute(ticket.id, BigInt(interaction.user.id), channel);
 
   const participants = await ticketRepo.listParticipants(ticket.id);
@@ -608,7 +609,7 @@ export const middlemanCommand: Command = {
               description: 'La acción solicitada no está implementada.',
             }),
           ],
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
     }
   },

--- a/src/presentation/commands/middleman/mm.ts
+++ b/src/presentation/commands/middleman/mm.ts
@@ -2,7 +2,8 @@
 // RUTA: src/presentation/commands/middleman/mm.ts
 // ============================================================================
 
-import { type ChatInputCommandInteraction,PermissionFlagsBits, SlashCommandBuilder } from 'discord.js';
+import type { ChatInputCommandInteraction } from 'discord.js';
+import { MessageFlags, PermissionFlagsBits, SlashCommandBuilder } from 'discord.js';
 
 import { prisma } from '@/infrastructure/db/prisma';
 import { PrismaMiddlemanRepository } from '@/infrastructure/repositories/PrismaMiddlemanRepository';
@@ -40,7 +41,7 @@ const handleAdd = async (interaction: ChatInputCommandInteraction): Promise<void
         description: `${target.toString()} ahora forma parte del directorio de middlemen con el usuario Roblox **${robloxUsername}**.`,
       }),
     ],
-    ephemeral: true,
+    flags: MessageFlags.Ephemeral,
   });
 };
 
@@ -64,7 +65,7 @@ const handleSet = async (interaction: ChatInputCommandInteraction): Promise<void
           : `${target.toString()} mantiene su información pero se actualizó la ficha.`,
       }),
     ],
-    ephemeral: true,
+    flags: MessageFlags.Ephemeral,
   });
 };
 
@@ -80,7 +81,7 @@ const handleStats = async (interaction: ChatInputCommandInteraction): Promise<vo
           description: `${target.toString()} todavía no cuenta con estadísticas como middleman.`,
         }),
       ],
-      ephemeral: true,
+      flags: MessageFlags.Ephemeral,
     });
     return;
   }
@@ -100,7 +101,7 @@ const handleStats = async (interaction: ChatInputCommandInteraction): Promise<vo
         description,
       }),
     ],
-    ephemeral: true,
+    flags: MessageFlags.Ephemeral,
   });
 };
 
@@ -116,7 +117,7 @@ const handleList = async (interaction: ChatInputCommandInteraction): Promise<voi
           description: 'Aún no se registran middlemen en el sistema.',
         }),
       ],
-      ephemeral: true,
+      flags: MessageFlags.Ephemeral,
     });
     return;
   }
@@ -133,7 +134,7 @@ const handleList = async (interaction: ChatInputCommandInteraction): Promise<voi
         description: lines.join('\n'),
       }),
     ],
-    ephemeral: true,
+    flags: MessageFlags.Ephemeral,
   });
 };
 
@@ -215,7 +216,7 @@ export const middlemanDirectoryCommand: Command = {
                 description: 'El subcomando solicitado no está implementado.',
               }),
             ],
-            ephemeral: true,
+            flags: MessageFlags.Ephemeral,
           });
       }
     } catch (error) {
@@ -236,7 +237,6 @@ export const middlemanDirectoryCommand: Command = {
               description: 'Ocurrió un problema al ejecutar el comando.',
             }),
           ],
-        ephemeral: true,
       });
     }
   },

--- a/src/presentation/commands/tickets/tickets.ts
+++ b/src/presentation/commands/tickets/tickets.ts
@@ -6,6 +6,7 @@ import {
   ChannelType,
   type ChatInputCommandInteraction,
   type GuildMember,
+  MessageFlags,
   SlashCommandBuilder,
 } from 'discord.js';
 
@@ -60,7 +61,7 @@ registerSelectMenuHandler(TICKET_PANEL_MENU_ID, async (interaction) => {
           description: 'Este menú solo puede usarse dentro de un servidor de Discord.',
         }),
       ],
-      ephemeral: true,
+      flags: MessageFlags.Ephemeral,
     });
     return;
   }
@@ -75,7 +76,7 @@ registerSelectMenuHandler(TICKET_PANEL_MENU_ID, async (interaction) => {
 
     const member = ensureGuildMember(interaction.member);
 
-    await interaction.deferReply({ ephemeral: true });
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
     const { ticket, channel } = await supportTicketUseCase.execute({
       guild: interaction.guild,
@@ -101,7 +102,7 @@ registerSelectMenuHandler(TICKET_PANEL_MENU_ID, async (interaction) => {
     }
 
     if (interaction.deferred || interaction.replied) {
-      const { ephemeral, flags, ...editPayload } = payload;
+      const { flags, ...editPayload } = payload;
       await interaction.editReply({
         ...editPayload,
         embeds:
@@ -124,7 +125,6 @@ registerSelectMenuHandler(TICKET_PANEL_MENU_ID, async (interaction) => {
             description: 'Verifica los requisitos e inténtalo nuevamente más tarde.',
           }),
         ],
-      ephemeral: true,
     });
   }
 });

--- a/src/presentation/components/modals/MiddlemanModal.ts
+++ b/src/presentation/components/modals/MiddlemanModal.ts
@@ -4,6 +4,7 @@
 
 import {
   ActionRowBuilder,
+  MessageFlags,
   ModalBuilder,
   type ModalSubmitInteraction,
   type TextChannel,
@@ -69,7 +70,7 @@ export class MiddlemanModal {
             description: 'Este formulario solo puede utilizarse dentro de un servidor de Discord.',
           }),
         ],
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
       });
       return;
     }
@@ -87,12 +88,12 @@ export class MiddlemanModal {
               'El bot no tiene configurada la categoría de middleman. Un administrador debe definir `MIDDLEMAN_CATEGORY_ID` en el archivo .env.',
           }),
         ],
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
       });
       return;
     }
 
-    await interaction.deferReply({ ephemeral: true });
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
     try {
       const { ticket, channel } = await useCase.execute(
@@ -143,7 +144,7 @@ export class MiddlemanModal {
       };
 
       if (interaction.deferred || interaction.replied) {
-        const { ephemeral, flags, ...editPayload } = payload;
+        const { flags, ...editPayload } = payload;
         await interaction.editReply(editPayload);
       } else {
         await interaction.reply(payload);

--- a/src/presentation/events/interactionCreate.ts
+++ b/src/presentation/events/interactionCreate.ts
@@ -9,7 +9,7 @@ import type {
   ModalSubmitInteraction,
   StringSelectMenuInteraction,
 } from 'discord.js';
-import { Events } from 'discord.js';
+import { Events, MessageFlags } from 'discord.js';
 
 import { commandRegistry } from '@/presentation/commands';
 import {
@@ -34,7 +34,7 @@ const handleChatInput = async (interaction: ChatInputCommandInteraction): Promis
           description: 'El comando solicitado ya no está registrado. Usa `/help` para ver la lista actual.',
         }),
       ],
-      ephemeral: true,
+      flags: MessageFlags.Ephemeral,
     });
     return;
   }
@@ -55,7 +55,7 @@ const handleButton = async (interaction: ButtonInteraction): Promise<void> => {
             'Este botón ya no está activo. Recarga la interfaz o ejecuta nuevamente el comando para obtener una versión actualizada.',
         }),
       ],
-      ephemeral: true,
+      flags: MessageFlags.Ephemeral,
     });
     return;
   }
@@ -75,7 +75,7 @@ const handleModal = async (interaction: ModalSubmitInteraction): Promise<void> =
           description: 'Este formulario ya no es válido. Intenta ejecutar nuevamente el flujo desde el comando original.',
         }),
       ],
-      ephemeral: true,
+      flags: MessageFlags.Ephemeral,
     });
     return;
   }
@@ -96,7 +96,7 @@ const handleSelectMenu = async (interaction: StringSelectMenuInteraction): Promi
             'Este menú ya no está activo. Vuelve a ejecutar el comando para obtener una versión actualizada.',
         }),
       ],
-      ephemeral: true,
+      flags: MessageFlags.Ephemeral,
     });
     return;
   }

--- a/src/shared/errors/base.error.ts
+++ b/src/shared/errors/base.error.ts
@@ -2,6 +2,8 @@
 // RUTA: src/shared/errors/base.error.ts
 // ============================================================================
 
+import { stripDiacritics, stripDiacriticsDeep } from '@/shared/utils/text';
+
 export interface DedosErrorOptions {
   readonly code: string;
   readonly message: string;
@@ -18,14 +20,17 @@ export class DedosError extends Error {
   public readonly exposeMessage: boolean;
 
   public constructor(options: DedosErrorOptions) {
-    super(options.message);
+    const sanitizedMessage = stripDiacritics(options.message);
+    const sanitizedMetadata = options.metadata ? stripDiacriticsDeep(options.metadata) : undefined;
+
+    super(sanitizedMessage);
     this.name = 'DedosError';
     this.code = options.code;
-    this.metadata = options.metadata ?? {};
+    this.metadata = sanitizedMetadata ?? {};
     this.exposeMessage = options.exposeMessage ?? false;
 
     if (options.cause) {
-      this.cause = options.cause;
+      this.cause = stripDiacriticsDeep(options.cause);
     }
 
     Error.captureStackTrace?.(this, DedosError);

--- a/src/shared/errors/discord-error-mapper.ts
+++ b/src/shared/errors/discord-error-mapper.ts
@@ -5,7 +5,7 @@
 import { randomUUID } from 'node:crypto';
 
 import type { InteractionReplyOptions } from 'discord.js';
-import { EmbedBuilder } from 'discord.js';
+import { EmbedBuilder, MessageFlags } from 'discord.js';
 
 import { COLORS, EMBED_LIMITS } from '@/shared/config/constants';
 import type { DedosError } from '@/shared/errors/base.error';
@@ -49,7 +49,7 @@ export const mapErrorToDiscordResponse = (error: unknown): DiscordErrorResponse 
 
   return {
     embeds: [buildErrorEmbed('Ha ocurrido un problema', description, referenceId)],
-    ephemeral: true,
+    flags: MessageFlags.Ephemeral,
     shouldLogStack,
     referenceId,
   };

--- a/src/shared/logger/pino.ts
+++ b/src/shared/logger/pino.ts
@@ -5,6 +5,7 @@
 import pinoLogger, { type Bindings, type Logger, type LoggerOptions } from 'pino';
 
 import { env } from '@/shared/config/env';
+import { stripDiacriticsDeep } from '@/shared/utils/text';
 
 const isDevelopment = env.NODE_ENV === 'development';
 
@@ -29,6 +30,15 @@ if (isDevelopment) {
     },
   };
 }
+
+const sanitizeArgs = (args: unknown[]): unknown[] => args.map((value) => stripDiacriticsDeep(value));
+
+options.hooks = {
+  logMethod(args, method) {
+    const sanitizedArgs = sanitizeArgs(args);
+    return Reflect.apply(method, this, sanitizedArgs);
+  },
+};
 
 export const logger = pinoLogger(options);
 

--- a/src/shared/utils/text.ts
+++ b/src/shared/utils/text.ts
@@ -1,0 +1,43 @@
+// ============================================================================
+// RUTA: src/shared/utils/text.ts
+// ============================================================================
+
+const DIACRITIC_REGEX = /[\u0300-\u036f]/g;
+
+export const stripDiacritics = (value: string): string =>
+  value.normalize('NFD').replace(DIACRITIC_REGEX, '');
+
+export const stripDiacriticsDeep = <T>(value: T): T => {
+  if (typeof value === 'string') {
+    return stripDiacritics(value) as T;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => stripDiacriticsDeep(item)) as unknown as T;
+  }
+
+  if (value && typeof value === 'object') {
+    if (value instanceof Date || value instanceof RegExp || value instanceof Map || value instanceof Set) {
+      return value;
+    }
+
+    if (value instanceof Error) {
+      value.message = stripDiacritics(value.message);
+      if (typeof value.stack === 'string') {
+        value.stack = stripDiacritics(value.stack);
+      }
+
+      return value;
+    }
+
+    const entries = Object.entries(value as Record<string, unknown>).map(([key, entryValue]) => [
+      key,
+      stripDiacriticsDeep(entryValue),
+    ]);
+
+    return Object.fromEntries(entries) as T;
+  }
+
+  return value;
+};
+


### PR DESCRIPTION
## Summary
- sanitize all logged error payloads to remove diacritics and update DedosError to normalize metadata
- replace deprecated `ephemeral` interaction responses with message flags across middleman and general commands
- align middleman ticket validation messaging and add shared text utilities for diacritic removal

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de272867248326b1ac5723a9fdbe91