### PR TITLE
Normalize Discord user metadata and Roblox identities

### DIFF
--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -1,0 +1,34 @@
+# Arquitectura operacional del bot de Dedos Shop
+
+## Panorama general de la aplicación
+El bot de Dedos Shop es una aplicación de Discord escrita en TypeScript que orquesta flujos de tickets, middleman y estadísticas comerciales. El punto de entrada inicia el cliente de Discord, prepara las dependencias de Prisma y registra los manejadores de comandos y eventos, garantizando que todas las interacciones se procesen bajo un contexto tipado y validado.【F:src/index.ts†L1-L74】
+
+Las operaciones clave de middleman se encapsulan en casos de uso como `OpenMiddlemanChannelUseCase`, que valida el contexto de la solicitud, crea los canales en Discord con los permisos adecuados y ejecuta la creación del ticket dentro de una transacción de base de datos para asegurar atomicidad entre la creación del canal y el registro persistente.【F:src/application/usecases/middleman/OpenMiddlemanChannelUseCase.ts†L34-L192】 Los mensajes de registro (`logger`) se emiten en cada etapa crítica para rastrear el ID del gremio, propietario y socio del trade, facilitando el seguimiento de incidentes en entornos de producción y desarrollo.【F:src/application/usecases/middleman/OpenMiddlemanChannelUseCase.ts†L87-L189】
+
+## Conexión y acceso a base de datos
+La capa de infraestructura utiliza Prisma Client para comunicarse con MySQL, configurado con niveles de log enriquecidos en entornos de desarrollo. El cliente se inicializa una única vez y se comparte de forma segura mediante `ensureDatabaseConnection`, lo que permite detectar problemas de conectividad de inmediato con trazas detalladas.【F:src/infrastructure/db/prisma.ts†L1-L33】
+
+El esquema de Prisma define modelos para usuarios, tickets, middlemen, trades y métricas asociadas. La tabla `users` ahora capta metadatos de Discord (username, global name, avatar, bandera de bot y marcas de primer/último avistamiento), mientras que la nueva tabla `guild_members` registra la pertenencia a cada servidor con alias, roles y fecha de ingreso. Para los datos de Roblox se introduce `user_roblox_identities`, que permite almacenar múltiples identidades por usuario y referenciarlas desde trades, perfiles de middleman y estadísticas sin perder el historial de cuentas utilizadas.【F:prisma/schema.prisma†L16-L222】
+
+## Garantía automática de registros de usuarios
+Para evitar errores de integridad referencial (como el código MySQL 1452), la capa de repositorios incorpora el utilitario `ensureUsersExist`. Esta función deduplica los identificadores recibidos, persiste los metadatos de Discord (incluidos username, discriminador y avatar) y sincroniza la membresía en cada gremio antes de ejecutar escrituras que dependan de claves foráneas.【F:src/infrastructure/repositories/utils/ensureUsersExist.ts†L1-L188】
+
+Los repositorios que insertan filas con claves foráneas a `users` invocan esta rutina antes de escribir datos. Esto cubre la creación de tickets (propietario y participantes) incluyendo la captura del estado actual de los miembros del gremio, trades, reseñas, perfiles de middleman y estadísticas de miembros, eliminando fallos por usuarios sin registrar y homogenizando el control de integridad en toda la aplicación.【F:src/infrastructure/repositories/PrismaTicketRepository.ts†L1-L296】【F:src/infrastructure/repositories/PrismaTradeRepository.ts†L1-L216】【F:src/infrastructure/repositories/PrismaReviewRepository.ts†L1-L126】【F:src/infrastructure/repositories/PrismaMiddlemanRepository.ts†L1-L244】【F:src/infrastructure/repositories/PrismaMemberStatsRepository.ts†L1-L62】
+
+## Flujo de creación y actualización de tickets
+Cuando se abre un canal de middleman:
+1. Se valida que el usuario no exceda el límite de tickets abiertos.
+2. Se crea el canal en Discord con permisos restringidos al propietario, socio y bot.
+3. Se asegura la existencia de los usuarios implicados en la base de datos.
+4. Se genera el ticket y se registran los participantes bajo una transacción de Prisma.
+5. Se envían mensajes informativos y se registran logs con contexto completo (ID del canal, ticket, gremio y participantes).【F:src/application/usecases/middleman/OpenMiddlemanChannelUseCase.ts†L54-L189】
+
+Los repositorios traducen los modelos de base de datos a entidades de dominio y viceversa, soportando tanto el esquema “moderno” (columnas con enums nativos) como uno “legacy” basado en catálogos, lo que facilita la migración desde estructuras anteriores sin sacrificar validaciones de dominio.【F:src/infrastructure/repositories/PrismaTicketRepository.ts†L24-L296】
+
+## Estrategia de depuración y trazabilidad
+El bot utiliza Pino como logger y, tras las mejoras, cada error incluye claves que permiten reconstruir rápidamente el contexto: IDs de gremio, canal, propietario, socio y categoría. Estas trazas acompañan los errores de creación de canal, fallos al persistir tickets y problemas durante la limpieza de recursos, lo que agiliza la identificación de causas raíz en incidentes reales.【F:src/application/usecases/middleman/OpenMiddlemanChannelUseCase.ts†L120-L189】
+
+Además, la configuración de Prisma habilita logs de consultas e información en modo desarrollo, combinados con las validaciones de Zod en DTOs, asegurando que los datos de entrada sean consistentes y que cualquier discrepancia se reporte con mensajes legibles antes de interactuar con la base de datos.【F:src/application/usecases/middleman/OpenMiddlemanChannelUseCase.ts†L34-L83】【F:src/infrastructure/db/prisma.ts†L1-L33】
+
+## Mantenimiento y extensibilidad futura
+Centralizar la garantía de usuarios registrados simplifica la evolución futura de la base de datos, ya que nuevas características que dependan de `userId` pueden reutilizar el mismo utilitario. Asimismo, la separación clara entre casos de uso, repositorios y entidades facilita agregar métricas, automatizar cierres de tickets o incorporar nuevas fuentes de autenticación sin reescribir el flujo existente.【F:src/application/usecases/middleman/OpenMiddlemanChannelUseCase.ts†L34-L192】【F:src/infrastructure/repositories/utils/ensureUsersExist.ts†L1-L36】

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -37,19 +37,26 @@ enum TradeStatus {
 }
 
 model User {
-  id            BigInt                 @id @map("id")
-  robloxId      BigInt?                @map("roblox_id")
-  createdAt     DateTime               @default(now()) @map("created_at")
+  id              BigInt                               @id @map("id")
+  username        String?                              @map("username")
+  discriminator   String?                              @map("discriminator")
+  globalName      String?                              @map("global_name")
+  avatarHash      String?                              @map("avatar_hash")
+  bot             Boolean                              @default(false) @map("bot")
+  firstSeenAt     DateTime                             @default(now()) @map("first_seen_at")
+  lastSeenAt      DateTime                             @default(now()) @map("last_seen_at")
 
-  warns         Warn[]
-  moderatedWarns Warn[]                @relation("WarnModerator")
-  tickets       Ticket[]               @relation("TicketOwner")
-  ticketRoles   TicketParticipant[]
-  middleman     Middleman?
-  mmTrades      MiddlemanTrade[]
-  authoredReviews MiddlemanReview[]    @relation("ReviewAuthor")
-  stats         MemberTradeStats?
+  warns           Warn[]
+  moderatedWarns  Warn[]                               @relation("WarnModerator")
+  tickets         Ticket[]                             @relation("TicketOwner")
+  ticketRoles     TicketParticipant[]
+  middleman       Middleman?
+  mmTrades        MiddlemanTrade[]
+  authoredReviews MiddlemanReview[]                    @relation("ReviewAuthor")
+  stats           MemberTradeStats?
   tradeFinalizations MiddlemanTradeFinalization[]
+  robloxIdentities UserRobloxIdentity[]
+  guildMemberships GuildMember[]
 
   @@map("users")
 }
@@ -106,38 +113,40 @@ model TicketParticipant {
 }
 
 model Middleman {
-  userId         BigInt          @id @map("user_id")
-  robloxUsername String          @map("roblox_username")
-  robloxUserId   BigInt?         @map("roblox_user_id")
-  createdAt      DateTime        @default(now()) @map("created_at")
-  updatedAt      DateTime        @updatedAt @map("updated_at")
+  userId                 BigInt              @id @map("user_id")
+  primaryRobloxIdentityId Int?               @map("primary_roblox_identity_id")
+  createdAt              DateTime            @default(now()) @map("created_at")
+  updatedAt              DateTime            @updatedAt @map("updated_at")
 
-  user           User            @relation(fields: [userId], references: [id], onDelete: Cascade)
-  claims         MiddlemanClaim[]
-  reviews        MiddlemanReview[] @relation("ReviewMiddleman")
+  user                   User                @relation(fields: [userId], references: [id], onDelete: Cascade)
+  primaryRobloxIdentity  UserRobloxIdentity? @relation("MiddlemanPrimaryIdentity", fields: [primaryRobloxIdentityId], references: [id], onDelete: SetNull)
+  claims                 MiddlemanClaim[]
+  reviews                MiddlemanReview[]   @relation("ReviewMiddleman")
 
-  @@index([robloxUserId])
   @@map("middlemen")
 }
 
 model MiddlemanTrade {
-  id             Int           @id @default(autoincrement())
-  ticketId       Int           @map("ticket_id")
-  userId         BigInt        @map("user_id")
-  robloxUsername String        @map("roblox_username")
-  robloxUserId   BigInt?       @map("roblox_user_id")
-  status         TradeStatus   @default(PENDING) @map("status")
-  confirmed      Boolean       @default(false) @map("confirmed")
-  createdAt      DateTime      @default(now()) @map("created_at")
-  updatedAt      DateTime      @updatedAt @map("updated_at")
+  id               Int                 @id @default(autoincrement())
+  ticketId         Int                 @map("ticket_id")
+  userId           BigInt              @map("user_id")
+  robloxIdentityId Int?                @map("roblox_identity_id")
+  robloxUsername   String              @map("roblox_username")
+  robloxUserId     BigInt?             @map("roblox_user_id")
+  status           TradeStatus         @default(PENDING) @map("status")
+  confirmed        Boolean             @default(false) @map("confirmed")
+  createdAt        DateTime            @default(now()) @map("created_at")
+  updatedAt        DateTime            @updatedAt @map("updated_at")
 
-  ticket         Ticket        @relation(fields: [ticketId], references: [id], onDelete: Cascade)
-  user           User          @relation(fields: [userId], references: [id], onDelete: Cascade)
-  items          MiddlemanTradeItem[]
+  ticket           Ticket              @relation(fields: [ticketId], references: [id], onDelete: Cascade)
+  user             User                @relation(fields: [userId], references: [id], onDelete: Cascade)
+  robloxIdentity   UserRobloxIdentity? @relation(fields: [robloxIdentityId], references: [id], onDelete: SetNull)
+  items            MiddlemanTradeItem[]
 
   @@unique([ticketId, userId])
   @@index([ticketId])
   @@index([userId])
+  @@index([robloxIdentityId])
   @@map("mm_trades")
 }
 
@@ -203,15 +212,51 @@ model MiddlemanTradeFinalization {
 }
 
 model MemberTradeStats {
-  userId         BigInt   @id @map("user_id")
-  tradesCompleted Int     @default(0) @map("trades_completed")
-  lastTradeAt     DateTime? @map("last_trade_at")
-  updatedAt       DateTime  @updatedAt @map("updated_at")
-  robloxUsername  String?   @map("roblox_username")
-  robloxUserId    BigInt?   @map("roblox_user_id")
-  partnerTag      String?   @map("partner_tag")
+  userId                   BigInt              @id @map("user_id")
+  tradesCompleted          Int                 @default(0) @map("trades_completed")
+  lastTradeAt              DateTime?           @map("last_trade_at")
+  updatedAt                DateTime            @updatedAt @map("updated_at")
+  preferredRobloxIdentityId Int?               @map("preferred_roblox_identity_id")
+  partnerTag               String?             @map("partner_tag")
 
-  user            User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user                     User                @relation(fields: [userId], references: [id], onDelete: Cascade)
+  preferredRobloxIdentity  UserRobloxIdentity? @relation("PreferredIdentity", fields: [preferredRobloxIdentityId], references: [id], onDelete: SetNull)
 
   @@map("member_trade_stats")
+}
+
+model UserRobloxIdentity {
+  id                Int                 @id @default(autoincrement())
+  userId            BigInt              @map("user_id")
+  robloxUserId      BigInt?             @map("roblox_user_id")
+  robloxUsername    String              @map("roblox_username")
+  verified          Boolean             @default(false) @map("verified")
+  createdAt         DateTime            @default(now()) @map("created_at")
+  updatedAt         DateTime            @updatedAt @map("updated_at")
+  lastUsedAt        DateTime?           @map("last_used_at")
+
+  user              User                @relation(fields: [userId], references: [id], onDelete: Cascade)
+  middlemanProfiles Middleman[]         @relation("MiddlemanPrimaryIdentity")
+  trades            MiddlemanTrade[]
+  preferredByStats  MemberTradeStats[]  @relation("PreferredIdentity")
+
+  @@index([userId])
+  @@index([robloxUserId])
+  @@unique([userId, robloxUsername])
+  @@map("user_roblox_identities")
+}
+
+model GuildMember {
+  guildId    BigInt   @map("guild_id")
+  userId     BigInt   @map("user_id")
+  nickname   String?  @map("nickname")
+  joinedAt   DateTime? @map("joined_at")
+  lastSeenAt DateTime  @default(now()) @map("last_seen_at")
+  roles      Json?     @map("roles")
+
+  user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@id([guildId, userId])
+  @@index([userId])
+  @@map("guild_members")
 }

--- a/src/application/usecases/tickets/OpenSupportTicketUseCase.ts
+++ b/src/application/usecases/tickets/OpenSupportTicketUseCase.ts
@@ -17,6 +17,7 @@ import {
   ValidationFailedError,
 } from '@/shared/errors/domain.errors';
 import { sanitizeChannelName } from '@/shared/utils/discord.utils';
+import { snapshotFromMember } from '@/shared/utils/discordIdentity';
 
 const cooldownTracker = new Map<string, number>();
 
@@ -133,6 +134,7 @@ export class OpenSupportTicketUseCase {
         ownerId,
         type,
         participants: [{ userId: ownerId, role: 'OWNER' }],
+        userSnapshots: [snapshotFromMember(member)],
       });
 
       cooldownTracker.set(cooldownKey, now);

--- a/src/domain/entities/Trade.ts
+++ b/src/domain/entities/Trade.ts
@@ -15,6 +15,7 @@ export class Trade {
     public readonly userId: bigint,
     public robloxUsername: string,
     public robloxUserId: bigint | null,
+    public robloxIdentityId: number | null,
     public status: TradeStatus,
     public confirmed: boolean,
     items: TradeItem[],
@@ -83,13 +84,19 @@ export class Trade {
     this.status = TradeStatus.PENDING;
   }
 
-  public updateRobloxProfile(details: { username?: string; userId?: bigint | null }): void {
+  public updateRobloxProfile(details: { username?: string; userId?: bigint | null; identityId?: number | null }): void {
     if (details.username) {
       this.robloxUsername = details.username;
     }
 
     if (details.userId !== undefined) {
       this.robloxUserId = details.userId;
+    }
+
+    if (details.identityId !== undefined) {
+      this.robloxIdentityId = details.identityId ?? null;
+    } else if (details.username) {
+      this.robloxIdentityId = null;
     }
   }
 

--- a/src/domain/repositories/IMiddlemanRepository.ts
+++ b/src/domain/repositories/IMiddlemanRepository.ts
@@ -13,10 +13,17 @@ export interface MiddlemanClaim {
   readonly forcedClose?: boolean;
 }
 
+export interface RobloxIdentityProfile {
+  readonly id: number;
+  readonly username: string;
+  readonly robloxUserId: bigint | null;
+  readonly verified: boolean;
+  readonly lastUsedAt: Date | null;
+}
+
 export interface MiddlemanProfile {
   readonly userId: bigint;
-  readonly robloxUsername: string;
-  readonly robloxUserId: bigint | null;
+  readonly primaryIdentity: RobloxIdentityProfile | null;
   readonly vouches: number;
   readonly ratingSum: number;
   readonly ratingCount: number;
@@ -28,8 +35,18 @@ export interface IMiddlemanRepository extends Transactional<IMiddlemanRepository
   createClaim(ticketId: number, middlemanId: bigint): Promise<void>;
   markClosed(ticketId: number, payload: { closedAt: Date; forcedClose?: boolean }): Promise<void>;
   markReviewRequested(ticketId: number, requestedAt: Date): Promise<void>;
-  upsertProfile(data: { userId: bigint; robloxUsername: string; robloxUserId?: bigint | null }): Promise<void>;
-  updateProfile(data: { userId: bigint; robloxUsername?: string | null; robloxUserId?: bigint | null }): Promise<void>;
+  upsertProfile(data: {
+    userId: bigint;
+    robloxUsername: string;
+    robloxUserId?: bigint | null;
+    verified?: boolean;
+  }): Promise<void>;
+  updateProfile(data: {
+    userId: bigint;
+    robloxUsername?: string | null;
+    robloxUserId?: bigint | null;
+    verified?: boolean;
+  }): Promise<void>;
   getProfile(userId: bigint): Promise<MiddlemanProfile | null>;
   listTopProfiles(limit?: number): Promise<readonly MiddlemanProfile[]>;
 }

--- a/src/domain/repositories/ITicketRepository.ts
+++ b/src/domain/repositories/ITicketRepository.ts
@@ -5,6 +5,7 @@
 import type { Ticket } from '@/domain/entities/Ticket';
 import type { TicketStatus, TicketType } from '@/domain/entities/types';
 import type { Transactional } from '@/domain/repositories/transaction';
+import type { DiscordUserSnapshot } from '@/shared/types/discord';
 
 export interface TicketParticipantInput {
   readonly userId: bigint;
@@ -19,6 +20,7 @@ export interface CreateTicketData {
   readonly type: TicketType;
   readonly status?: TicketStatus;
   readonly participants?: ReadonlyArray<TicketParticipantInput>;
+  readonly userSnapshots?: ReadonlyArray<DiscordUserSnapshot>;
 }
 
 export interface ITicketRepository extends Transactional<ITicketRepository> {

--- a/src/domain/repositories/ITradeRepository.ts
+++ b/src/domain/repositories/ITradeRepository.ts
@@ -6,6 +6,7 @@ import type { Trade } from '@/domain/entities/Trade';
 import type { TradeItem } from '@/domain/entities/types';
 import type { Transactional } from '@/domain/repositories/transaction';
 import type { TradeStatus } from '@/domain/value-objects/TradeStatus';
+import type { DiscordUserSnapshot } from '@/shared/types/discord';
 
 export interface CreateTradeData {
   readonly ticketId: number;
@@ -15,6 +16,7 @@ export interface CreateTradeData {
   readonly status?: TradeStatus;
   readonly confirmed?: boolean;
   readonly items?: ReadonlyArray<TradeItem>;
+  readonly userSnapshot?: DiscordUserSnapshot;
 }
 
 export interface ITradeRepository extends Transactional<ITradeRepository> {

--- a/src/infrastructure/repositories/PrismaMemberStatsRepository.ts
+++ b/src/infrastructure/repositories/PrismaMemberStatsRepository.ts
@@ -6,6 +6,7 @@ import type { Prisma, PrismaClient } from '@prisma/client';
 
 import type { IMemberStatsRepository } from '@/domain/repositories/IMemberStatsRepository';
 import type { TransactionContext } from '@/domain/repositories/transaction';
+import { ensureUsersExist } from '@/infrastructure/repositories/utils/ensureUsersExist';
 
 type PrismaClientLike = PrismaClient | Prisma.TransactionClient;
 
@@ -21,6 +22,8 @@ export class PrismaMemberStatsRepository implements IMemberStatsRepository {
   }
 
   public async recordCompletedTrade(userId: bigint, completedAt: Date): Promise<void> {
+    await ensureUsersExist(this.prisma, [userId]);
+
     await this.prisma.memberTradeStats.upsert({
       where: { userId },
       create: {

--- a/src/infrastructure/repositories/PrismaReviewRepository.ts
+++ b/src/infrastructure/repositories/PrismaReviewRepository.ts
@@ -8,6 +8,7 @@ import { Review } from '@/domain/entities/Review';
 import type { CreateReviewData, IReviewRepository } from '@/domain/repositories/IReviewRepository';
 import type { TransactionContext } from '@/domain/repositories/transaction';
 import { Rating } from '@/domain/value-objects/Rating';
+import { ensureUsersExist } from '@/infrastructure/repositories/utils/ensureUsersExist';
 
 type PrismaClientLike = PrismaClient | Prisma.TransactionClient;
 
@@ -25,6 +26,8 @@ export class PrismaReviewRepository implements IReviewRepository {
   }
 
   public async create(data: CreateReviewData): Promise<Review> {
+    await ensureUsersExist(this.prisma, [data.reviewerId]);
+
     const review = await this.prisma.middlemanReview.create({
       data: {
         ticketId: data.ticketId,

--- a/src/infrastructure/repositories/utils/ensureUsersExist.ts
+++ b/src/infrastructure/repositories/utils/ensureUsersExist.ts
@@ -1,0 +1,194 @@
+// ============================================================================
+// RUTA: src/infrastructure/repositories/utils/ensureUsersExist.ts
+// ============================================================================
+
+import type { Prisma, PrismaClient } from '@prisma/client';
+
+import type { DiscordUserSnapshot } from '@/shared/types/discord';
+
+const isBigInt = (value: unknown): value is bigint => typeof value === 'bigint';
+
+const normalizeDate = (value?: Date | null): Date => {
+  if (value instanceof Date && !Number.isNaN(value.getTime())) {
+    return value;
+  }
+
+  return new Date();
+};
+
+interface UserSnapshotData {
+  readonly userId: bigint;
+  readonly username?: string | null;
+  readonly discriminator?: string | null;
+  readonly globalName?: string | null;
+  readonly avatarHash?: string | null;
+  readonly bot?: boolean;
+  readonly seenAt: Date;
+}
+
+interface MembershipSnapshotData {
+  readonly guildId: bigint;
+  readonly userId: bigint;
+  readonly nickname?: string | null;
+  readonly joinedAt?: Date | null;
+  readonly roles?: readonly string[];
+  readonly seenAt: Date;
+}
+
+interface SnapshotParts {
+  readonly user: UserSnapshotData;
+  readonly membership?: MembershipSnapshotData;
+}
+
+type SnapshotInput = bigint | DiscordUserSnapshot;
+
+const toSnapshotParts = (input: SnapshotInput): SnapshotParts => {
+  if (isBigInt(input)) {
+    const seenAt = new Date();
+    return {
+      user: {
+        userId: input,
+        seenAt,
+      },
+    };
+  }
+
+  const seenAt = normalizeDate(input.seenAt);
+  const user: UserSnapshotData = {
+    userId: input.id,
+    username: input.username ?? undefined,
+    discriminator: input.discriminator ?? undefined,
+    globalName: input.globalName ?? undefined,
+    avatarHash: input.avatarHash ?? undefined,
+    bot: input.bot ?? undefined,
+    seenAt,
+  };
+
+  if (!input.guildId) {
+    return { user };
+  }
+
+  const membership: MembershipSnapshotData = {
+    guildId: input.guildId,
+    userId: input.id,
+    nickname: input.nickname ?? undefined,
+    joinedAt: input.joinedAt ?? undefined,
+    roles: input.roles ?? undefined,
+    seenAt,
+  };
+
+  return { user, membership };
+};
+
+const mergeUserSnapshots = (current: UserSnapshotData, incoming: UserSnapshotData): UserSnapshotData => ({
+  userId: current.userId,
+  username: incoming.username !== undefined ? incoming.username : current.username,
+  discriminator: incoming.discriminator !== undefined ? incoming.discriminator : current.discriminator,
+  globalName: incoming.globalName !== undefined ? incoming.globalName : current.globalName,
+  avatarHash: incoming.avatarHash !== undefined ? incoming.avatarHash : current.avatarHash,
+  bot: incoming.bot !== undefined ? incoming.bot : current.bot,
+  seenAt: incoming.seenAt > current.seenAt ? incoming.seenAt : current.seenAt,
+});
+
+const mergeMembershipSnapshots = (
+  current: MembershipSnapshotData,
+  incoming: MembershipSnapshotData,
+): MembershipSnapshotData => ({
+  guildId: current.guildId,
+  userId: current.userId,
+  nickname: incoming.nickname !== undefined ? incoming.nickname : current.nickname,
+  joinedAt: incoming.joinedAt !== undefined ? incoming.joinedAt : current.joinedAt,
+  roles: incoming.roles !== undefined ? incoming.roles : current.roles,
+  seenAt: incoming.seenAt > current.seenAt ? incoming.seenAt : current.seenAt,
+});
+
+const withNullable = <T>(value: T | null | undefined): T | null | undefined =>
+  value === undefined ? undefined : value;
+
+const withBoolean = (value: boolean | undefined): boolean | undefined =>
+  value === undefined ? undefined : value;
+
+const buildMembershipKey = (snapshot: MembershipSnapshotData): string =>
+  `${snapshot.guildId.toString()}:${snapshot.userId.toString()}`;
+
+export const ensureUsersExist = async (
+  prisma: PrismaClient | Prisma.TransactionClient,
+  rawInputs: readonly (SnapshotInput | undefined | null)[],
+): Promise<void> => {
+  const inputs = rawInputs.filter((value): value is SnapshotInput => value !== null && value !== undefined);
+
+  if (inputs.length === 0) {
+    return;
+  }
+
+  const userSnapshots = new Map<bigint, UserSnapshotData>();
+  const membershipSnapshots = new Map<string, MembershipSnapshotData>();
+
+  for (const input of inputs) {
+    const parts = toSnapshotParts(input);
+    const existingUser = userSnapshots.get(parts.user.userId);
+
+    userSnapshots.set(parts.user.userId, existingUser ? mergeUserSnapshots(existingUser, parts.user) : parts.user);
+
+    if (parts.membership) {
+      const key = buildMembershipKey(parts.membership);
+      const existingMembership = membershipSnapshots.get(key);
+      membershipSnapshots.set(
+        key,
+        existingMembership ? mergeMembershipSnapshots(existingMembership, parts.membership) : parts.membership,
+      );
+    }
+  }
+
+  const userUpserts = Array.from(userSnapshots.values(), async (snapshot) => {
+    await prisma.user.upsert({
+      where: { id: snapshot.userId },
+      create: {
+        id: snapshot.userId,
+        username: snapshot.username ?? null,
+        discriminator: snapshot.discriminator ?? null,
+        globalName: snapshot.globalName ?? null,
+        avatarHash: snapshot.avatarHash ?? null,
+        bot: snapshot.bot ?? false,
+        firstSeenAt: snapshot.seenAt,
+        lastSeenAt: snapshot.seenAt,
+      },
+      update: {
+        username: withNullable(snapshot.username),
+        discriminator: withNullable(snapshot.discriminator),
+        globalName: withNullable(snapshot.globalName),
+        avatarHash: withNullable(snapshot.avatarHash),
+        bot: withBoolean(snapshot.bot),
+        lastSeenAt: snapshot.seenAt,
+      },
+    });
+  });
+
+  await Promise.all(userUpserts);
+
+  if (membershipSnapshots.size === 0) {
+    return;
+  }
+
+  const membershipUpserts = Array.from(membershipSnapshots.values(), async (snapshot) => {
+    await prisma.guildMember.upsert({
+      where: { guildId_userId: { guildId: snapshot.guildId, userId: snapshot.userId } },
+      create: {
+        guildId: snapshot.guildId,
+        userId: snapshot.userId,
+        nickname: snapshot.nickname ?? null,
+        joinedAt: snapshot.joinedAt ?? null,
+        lastSeenAt: snapshot.seenAt,
+        roles: snapshot.roles ? [...snapshot.roles] : undefined,
+      },
+      update: {
+        nickname: withNullable(snapshot.nickname),
+        joinedAt: withNullable(snapshot.joinedAt),
+        lastSeenAt: snapshot.seenAt,
+        roles: snapshot.roles ? [...snapshot.roles] : undefined,
+      },
+    });
+  });
+
+  await Promise.all(membershipUpserts);
+};

--- a/src/presentation/commands/middleman/mm.ts
+++ b/src/presentation/commands/middleman/mm.ts
@@ -87,8 +87,9 @@ const handleStats = async (interaction: ChatInputCommandInteraction): Promise<vo
   }
 
   const average = profile.ratingCount > 0 ? profile.ratingSum / profile.ratingCount : 0;
+  const robloxUsername = profile.primaryIdentity?.username ?? 'Sin registrar';
   const description = [
-    `• Usuario de Roblox: **${profile.robloxUsername}**`,
+    `• Usuario de Roblox: **${robloxUsername}**`,
     `• Vouches registrados: **${profile.vouches}**`,
     `• Valoraciones recibidas: **${profile.ratingCount}**`,
     `• Promedio actual: **${average.toFixed(2)} ⭐**`,
@@ -124,7 +125,8 @@ const handleList = async (interaction: ChatInputCommandInteraction): Promise<voi
 
   const lines = profiles.map((profile, index) => {
     const average = profile.ratingCount > 0 ? profile.ratingSum / profile.ratingCount : 0;
-    return `${index + 1}. <@${profile.userId.toString()}> — Roblox: **${profile.robloxUsername}** | Vouches: ${profile.vouches} | Rating: ${average.toFixed(2)} (${profile.ratingCount})`;
+    const robloxUsername = profile.primaryIdentity?.username ?? 'Sin registrar';
+    return `${index + 1}. <@${profile.userId.toString()}> — Roblox: **${robloxUsername}** | Vouches: ${profile.vouches} | Rating: ${average.toFixed(2)} (${profile.ratingCount})`;
   });
 
   await interaction.reply({

--- a/src/shared/types/discord.ts
+++ b/src/shared/types/discord.ts
@@ -1,0 +1,17 @@
+// ============================================================================
+// RUTA: src/shared/types/discord.ts
+// ============================================================================
+
+export interface DiscordUserSnapshot {
+  readonly id: bigint;
+  readonly username?: string | null;
+  readonly discriminator?: string | null;
+  readonly globalName?: string | null;
+  readonly avatarHash?: string | null;
+  readonly bot?: boolean;
+  readonly seenAt?: Date;
+  readonly guildId?: bigint;
+  readonly nickname?: string | null;
+  readonly joinedAt?: Date | null;
+  readonly roles?: readonly string[];
+}

--- a/src/shared/utils/discordIdentity.ts
+++ b/src/shared/utils/discordIdentity.ts
@@ -1,0 +1,33 @@
+// ============================================================================
+// RUTA: src/shared/utils/discordIdentity.ts
+// ============================================================================
+
+import type { GuildMember, User } from 'discord.js';
+
+import type { DiscordUserSnapshot } from '@/shared/types/discord';
+
+const normalizeRoles = (roles: readonly string[] | undefined): readonly string[] | undefined => {
+  if (!roles || roles.length === 0) {
+    return undefined;
+  }
+
+  return Array.from(new Set(roles));
+};
+
+export const snapshotFromUser = (user: User, seenAt: Date = new Date()): DiscordUserSnapshot => ({
+  id: BigInt(user.id),
+  username: user.username,
+  discriminator: 'discriminator' in user ? user.discriminator : undefined,
+  globalName: 'globalName' in user ? user.globalName : undefined,
+  avatarHash: user.avatar ?? undefined,
+  bot: user.bot,
+  seenAt,
+});
+
+export const snapshotFromMember = (member: GuildMember, seenAt: Date = new Date()): DiscordUserSnapshot => ({
+  ...snapshotFromUser(member.user, seenAt),
+  guildId: BigInt(member.guild.id),
+  nickname: member.nickname,
+  joinedAt: member.joinedAt ?? undefined,
+  roles: normalizeRoles(member.roles.cache.map((role) => role.id)),
+});

--- a/tests/unit/application/usecases/ConfirmTradeUseCase.test.ts
+++ b/tests/unit/application/usecases/ConfirmTradeUseCase.test.ts
@@ -115,8 +115,8 @@ describe('ConfirmTradeUseCase', () => {
     ticketRepo.ticket = new Ticket(1, BigInt(OWNER_ID), BigInt(2), BigInt(PARTNER_ID), TicketType.MM, TicketStatus.OPEN, new Date());
     ticketRepo.participants = new Set([OWNER_ID, PARTNER_ID]);
 
-    const tradeA = new Trade(1, 1, BigInt(OWNER_ID), 'TraderA', null, TradeStatus.PENDING, false, [], new Date());
-    const tradeB = new Trade(2, 1, BigInt(PARTNER_ID), 'TraderB', null, TradeStatus.PENDING, false, [], new Date());
+    const tradeA = new Trade(1, 1, BigInt(OWNER_ID), 'TraderA', null, null, TradeStatus.PENDING, false, [], new Date());
+    const tradeB = new Trade(2, 1, BigInt(PARTNER_ID), 'TraderB', null, null, TradeStatus.PENDING, false, [], new Date());
     tradeRepo.trades = [tradeA, tradeB];
   });
 

--- a/tests/unit/application/usecases/SubmitTradeDataUseCase.test.ts
+++ b/tests/unit/application/usecases/SubmitTradeDataUseCase.test.ts
@@ -78,6 +78,7 @@ class MockTradeRepository implements ITradeRepository {
       data.userId,
       data.robloxUsername,
       data.robloxUserId ?? null,
+      null,
       data.status ?? TradeStatus.PENDING,
       data.confirmed ?? false,
       data.items ? [...data.items] : [],
@@ -152,7 +153,7 @@ describe('SubmitTradeDataUseCase', () => {
   });
 
   it('updates existing trade and resets confirmation', async () => {
-    const existing = new Trade(1, 1, BigInt(PARTNER_ID), 'OldName', null, TradeStatus.ACTIVE, true, [], new Date());
+    const existing = new Trade(1, 1, BigInt(PARTNER_ID), 'OldName', null, null, TradeStatus.ACTIVE, true, [], new Date());
     tradeRepo.trades = [existing];
 
     const dto: SubmitTradeDataDTO = {

--- a/tests/unit/infrastructure/repositories/PrismaTradeRepository.test.ts
+++ b/tests/unit/infrastructure/repositories/PrismaTradeRepository.test.ts
@@ -16,6 +16,7 @@ const buildTrade = (items: Parameters<Trade['replaceItems']>[0]): Trade =>
     BigInt('123456789012345678'),
     'JohnDoe',
     null,
+    null,
     TradeStatus.ACTIVE,
     true,
     items,
@@ -28,9 +29,12 @@ describe('PrismaTradeRepository.update', () => {
     const innerDeleteMany = vi.fn(async () => {});
     const innerCreateMany = vi.fn(async () => {});
 
+    const identity = { id: 73, robloxUserId: BigInt('987654321098765432') };
+
     const txStub = {
       middlemanTrade: { update: innerUpdate },
       middlemanTradeItem: { deleteMany: innerDeleteMany, createMany: innerCreateMany },
+      userRobloxIdentity: { upsert: vi.fn().mockResolvedValue(identity) },
     } satisfies Partial<Prisma.TransactionClient>;
 
     const outerUpdate = vi.fn();
@@ -43,6 +47,7 @@ describe('PrismaTradeRepository.update', () => {
       $transaction: vi.fn(async (callback: (tx: Prisma.TransactionClient) => Promise<void>) => {
         await callback(txStub as Prisma.TransactionClient);
       }),
+      userRobloxIdentity: { upsert: vi.fn().mockResolvedValue(identity) },
     };
 
     const repository = new PrismaTradeRepository(prismaClientMock as unknown as PrismaClient);
@@ -59,8 +64,9 @@ describe('PrismaTradeRepository.update', () => {
       data: {
         status: trade.status,
         confirmed: trade.confirmed,
-        robloxUserId: trade.robloxUserId,
+        robloxUserId: identity.robloxUserId,
         robloxUsername: trade.robloxUsername,
+        robloxIdentityId: identity.id,
       },
     });
     expect(innerDeleteMany).toHaveBeenCalledWith({ where: { tradeId: trade.id } });
@@ -83,16 +89,22 @@ describe('PrismaTradeRepository.update', () => {
     expect(outerUpdate).not.toHaveBeenCalled();
     expect(outerDeleteMany).not.toHaveBeenCalled();
     expect(outerCreateMany).not.toHaveBeenCalled();
+    expect(txStub.userRobloxIdentity?.upsert).toHaveBeenCalled();
+    expect(trade.robloxUserId).toBe(identity.robloxUserId);
+    expect(trade.robloxIdentityId).toBe(identity.id);
   });
 
   it('reutiliza el cliente transaccional cuando no se dispone de $transaction', async () => {
+    const identity = { id: 81, robloxUserId: BigInt('111222333444555666') };
     const update = vi.fn(async () => {});
     const deleteMany = vi.fn(async () => {});
     const createMany = vi.fn(async () => {});
+    const upsertIdentity = vi.fn().mockResolvedValue(identity);
 
     const transactionClient = {
       middlemanTrade: { update },
       middlemanTradeItem: { deleteMany, createMany },
+      userRobloxIdentity: { upsert: upsertIdentity },
     } as unknown as Prisma.TransactionClient;
 
     const repository = new PrismaTradeRepository(transactionClient);
@@ -105,12 +117,14 @@ describe('PrismaTradeRepository.update', () => {
       data: {
         status: trade.status,
         confirmed: trade.confirmed,
-        robloxUserId: trade.robloxUserId,
+        robloxUserId: identity.robloxUserId,
         robloxUsername: trade.robloxUsername,
+        robloxIdentityId: identity.id,
       },
     });
     expect(deleteMany).toHaveBeenCalledWith({ where: { tradeId: trade.id } });
     expect(createMany).not.toHaveBeenCalled();
+    expect(upsertIdentity).toHaveBeenCalled();
+    expect(trade.robloxIdentityId).toBe(identity.id);
   });
 });
-


### PR DESCRIPTION
## Summary
- restructure the Prisma schema to store Discord user metadata, guild memberships, and reusable Roblox identities referenced by trades and middleman profiles
- capture Discord member snapshots for ticket creation and extend Prisma repositories to upsert Roblox identities automatically during trade and middleman operations
- document the new persistence model in the system overview to explain how user caches and identity records are synchronized

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68deed3180448326be6cc8e6e134e1cf