### PR TITLE
chore: auto sync database schema with Prisma

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,7 @@ REVIEW_CHANNEL_ID=123456789012345678
 # =========================================================
 DATABASE_URL="mysql://dedos:dedos@localhost:3306/dedos_shop"
 # DATABASE_URL="postgresql://dedos:dedos@localhost:5432/dedos_shop?schema=public"
+DB_AUTO_APPLY_SCHEMA=true
 
 # =========================================================
 # Redis cache (optional for v1)

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -1,5 +1,5 @@
 -- =========================================
--- Dedos Shop Bot - DB (Normalizado v2)
+-- Dedos Shop Bot - Base de datos (Prisma v6)
 -- =========================================
 
 CREATE DATABASE IF NOT EXISTS dedos_shop
@@ -10,212 +10,209 @@ SET NAMES utf8mb4;
 SET time_zone = "+00:00";
 SET sql_mode = 'STRICT_ALL_TABLES,NO_ZERO_DATE,NO_ZERO_IN_DATE';
 
--- ===========================
--- Catálogos (antes ENUMs)
--- ===========================
-
-CREATE TABLE warn_severities (
-  id TINYINT UNSIGNED PRIMARY KEY AUTO_INCREMENT,
-  name VARCHAR(16) NOT NULL UNIQUE
-) ENGINE=InnoDB;
-
-INSERT IGNORE INTO warn_severities (id, name) VALUES
-  (1,'minor'), (2,'major'), (3,'critical');
-
-CREATE TABLE ticket_types (
-  id TINYINT UNSIGNED PRIMARY KEY AUTO_INCREMENT,
-  name VARCHAR(32) NOT NULL UNIQUE
-) ENGINE=InnoDB;
-
-INSERT IGNORE INTO ticket_types (id, name) VALUES
-  (1,'buy'),(2,'sell'),(3,'robux'),(4,'nitro'),(5,'decor'),(6,'mm');
-
-CREATE TABLE ticket_statuses (
-  id TINYINT UNSIGNED PRIMARY KEY AUTO_INCREMENT,
-  name VARCHAR(16) NOT NULL UNIQUE
-) ENGINE=InnoDB;
-
-INSERT IGNORE INTO ticket_statuses (id, name) VALUES
-  (1,'OPEN'),(2,'CONFIRMED'),(3,'CLAIMED'),(4,'CLOSED');
-
 -- =========================================
--- Usuarios (Discord y Roblox)
+-- Tablas base sincronizadas con prisma/schema.prisma
 -- =========================================
 
-CREATE TABLE users (
-  id BIGINT UNSIGNED PRIMARY KEY,     -- Discord snowflake
-  roblox_id BIGINT UNSIGNED NULL,
-  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-) ENGINE=InnoDB;
+CREATE TABLE IF NOT EXISTS `users` (
+  `id` BIGINT UNSIGNED NOT NULL,
+  `username` VARCHAR(191) NULL,
+  `discriminator` VARCHAR(191) NULL,
+  `global_name` VARCHAR(191) NULL,
+  `avatar_hash` VARCHAR(191) NULL,
+  `bot` TINYINT(1) NOT NULL DEFAULT 0,
+  `first_seen_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  `last_seen_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `warns` (
+  `id` INT NOT NULL AUTO_INCREMENT,
+  `user_id` BIGINT UNSIGNED NOT NULL,
+  `moderator_id` BIGINT UNSIGNED NULL,
+  `severity` ENUM('MINOR','MAJOR','CRITICAL') NOT NULL,
+  `reason` TEXT NULL,
+  `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  INDEX `warns_user_id_created_at_idx` (`user_id`, `created_at` DESC),
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `tickets` (
+  `id` INT NOT NULL AUTO_INCREMENT,
+  `guild_id` BIGINT UNSIGNED NOT NULL,
+  `channel_id` BIGINT UNSIGNED NOT NULL,
+  `owner_id` BIGINT UNSIGNED NOT NULL,
+  `type` ENUM('BUY','SELL','ROBUX','NITRO','DECOR','MM') NOT NULL,
+  `status` ENUM('OPEN','CONFIRMED','CLAIMED','CLOSED') NOT NULL DEFAULT 'OPEN',
+  `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  `closed_at` DATETIME(3) NULL,
+  UNIQUE INDEX `tickets_channel_id_key` (`channel_id`),
+  INDEX `tickets_owner_id_status_idx` (`owner_id`, `status`),
+  INDEX `tickets_guild_id_created_at_idx` (`guild_id`, `created_at` DESC),
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `ticket_participants` (
+  `ticket_id` INT NOT NULL,
+  `user_id` BIGINT UNSIGNED NOT NULL,
+  `role` VARCHAR(24) NULL,
+  `joined_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  INDEX `ticket_participants_user_id_idx` (`user_id`),
+  PRIMARY KEY (`ticket_id`, `user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `user_roblox_identities` (
+  `id` INT NOT NULL AUTO_INCREMENT,
+  `user_id` BIGINT UNSIGNED NOT NULL,
+  `roblox_user_id` BIGINT NULL,
+  `roblox_username` VARCHAR(191) NOT NULL,
+  `verified` TINYINT(1) NOT NULL DEFAULT 0,
+  `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  `updated_at` DATETIME(3) NOT NULL,
+  `last_used_at` DATETIME(3) NULL,
+  INDEX `user_roblox_identities_user_id_idx` (`user_id`),
+  INDEX `user_roblox_identities_roblox_user_id_idx` (`roblox_user_id`),
+  UNIQUE INDEX `user_roblox_identities_user_id_roblox_username_key` (`user_id`, `roblox_username`),
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `middlemen` (
+  `user_id` BIGINT UNSIGNED NOT NULL,
+  `primary_roblox_identity_id` INT NULL,
+  `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  `updated_at` DATETIME(3) NOT NULL,
+  PRIMARY KEY (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `mm_trades` (
+  `id` INT NOT NULL AUTO_INCREMENT,
+  `ticket_id` INT NOT NULL,
+  `user_id` BIGINT UNSIGNED NOT NULL,
+  `roblox_identity_id` INT NULL,
+  `roblox_username` VARCHAR(191) NOT NULL,
+  `roblox_user_id` BIGINT NULL,
+  `status` ENUM('PENDING','ACTIVE','COMPLETED','CANCELLED') NOT NULL DEFAULT 'PENDING',
+  `confirmed` TINYINT(1) NOT NULL DEFAULT 0,
+  `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  `updated_at` DATETIME(3) NOT NULL,
+  INDEX `mm_trades_ticket_id_idx` (`ticket_id`),
+  INDEX `mm_trades_user_id_idx` (`user_id`),
+  INDEX `mm_trades_roblox_identity_id_idx` (`roblox_identity_id`),
+  UNIQUE INDEX `mm_trades_ticket_id_user_id_key` (`ticket_id`, `user_id`),
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `mm_trade_items` (
+  `id` INT NOT NULL AUTO_INCREMENT,
+  `trade_id` INT NOT NULL,
+  `item_name` VARCHAR(191) NOT NULL,
+  `quantity` INT NOT NULL DEFAULT 1,
+  `metadata` JSON NULL,
+  INDEX `mm_trade_items_trade_id_idx` (`trade_id`),
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `mm_claims` (
+  `ticket_id` INT NOT NULL,
+  `middleman_id` BIGINT UNSIGNED NOT NULL,
+  `claimed_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  `review_requested_at` DATETIME(3) NULL,
+  `closed_at` DATETIME(3) NULL,
+  `vouched` TINYINT(1) NOT NULL DEFAULT 0,
+  `forced_close` TINYINT(1) NOT NULL DEFAULT 0,
+  `panel_message_id` BIGINT NULL,
+  `finalization_message_id` BIGINT NULL,
+  INDEX `mm_claims_middleman_id_claimed_at_idx` (`middleman_id`, `claimed_at` DESC),
+  PRIMARY KEY (`ticket_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `mm_reviews` (
+  `id` INT NOT NULL AUTO_INCREMENT,
+  `ticket_id` INT NOT NULL,
+  `reviewer_id` BIGINT UNSIGNED NOT NULL,
+  `middleman_id` BIGINT UNSIGNED NOT NULL,
+  `stars` INT NOT NULL,
+  `review_text` TEXT NULL,
+  `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  INDEX `mm_reviews_middleman_id_created_at_idx` (`middleman_id`, `created_at` DESC),
+  UNIQUE INDEX `mm_reviews_ticket_id_reviewer_id_key` (`ticket_id`, `reviewer_id`),
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `mm_trade_finalizations` (
+  `ticket_id` INT NOT NULL,
+  `user_id` BIGINT UNSIGNED NOT NULL,
+  `confirmed_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  PRIMARY KEY (`ticket_id`, `user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `member_trade_stats` (
+  `user_id` BIGINT UNSIGNED NOT NULL,
+  `trades_completed` INT NOT NULL DEFAULT 0,
+  `last_trade_at` DATETIME(3) NULL,
+  `updated_at` DATETIME(3) NOT NULL,
+  `preferred_roblox_identity_id` INT NULL,
+  `partner_tag` VARCHAR(191) NULL,
+  PRIMARY KEY (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `guild_members` (
+  `guild_id` BIGINT UNSIGNED NOT NULL,
+  `user_id` BIGINT UNSIGNED NOT NULL,
+  `nickname` VARCHAR(191) NULL,
+  `joined_at` DATETIME(3) NULL,
+  `last_seen_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  `roles` JSON NULL,
+  INDEX `guild_members_user_id_idx` (`user_id`),
+  PRIMARY KEY (`guild_id`, `user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- =========================================
--- Warns
+-- Relaciones y llaves foráneas
 -- =========================================
 
-CREATE TABLE warns (
-  id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-  user_id BIGINT UNSIGNED NOT NULL,
-  moderator_id BIGINT UNSIGNED NULL,
-  severity_id TINYINT UNSIGNED NOT NULL,
-  reason TEXT,
-  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  INDEX idx_warns_user_created (user_id, created_at DESC),
-  CONSTRAINT fk_warns_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
-  CONSTRAINT fk_warns_mod FOREIGN KEY (moderator_id) REFERENCES users(id) ON DELETE SET NULL,
-  CONSTRAINT fk_warns_sev FOREIGN KEY (severity_id) REFERENCES warn_severities(id)
-) ENGINE=InnoDB;
+ALTER TABLE `warns`
+  ADD CONSTRAINT `warns_user_id_fkey` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT `warns_moderator_id_fkey` FOREIGN KEY (`moderator_id`) REFERENCES `users` (`id`) ON DELETE SET NULL ON UPDATE CASCADE;
 
--- =========================================
--- Tickets
--- =========================================
+ALTER TABLE `tickets`
+  ADD CONSTRAINT `tickets_owner_id_fkey` FOREIGN KEY (`owner_id`) REFERENCES `users` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;
 
-CREATE TABLE tickets (
-  id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-  guild_id BIGINT UNSIGNED NOT NULL,
-  channel_id BIGINT UNSIGNED NOT NULL,
-  owner_id BIGINT UNSIGNED NOT NULL,
-  type_id TINYINT UNSIGNED NOT NULL,
-  status_id TINYINT UNSIGNED NOT NULL DEFAULT 1, -- OPEN
+ALTER TABLE `ticket_participants`
+  ADD CONSTRAINT `ticket_participants_ticket_id_fkey` FOREIGN KEY (`ticket_id`) REFERENCES `tickets` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT `ticket_participants_user_id_fkey` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;
 
-  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  closed_at TIMESTAMP NULL,
-  INDEX idx_tickets_owner_status (owner_id, status_id),
-  INDEX idx_tickets_channel (channel_id),
-  INDEX idx_tickets_guild_created (guild_id, created_at DESC),
-  CONSTRAINT fk_tickets_owner FOREIGN KEY (owner_id) REFERENCES users(id) ON DELETE CASCADE,
-  CONSTRAINT fk_tickets_type FOREIGN KEY (type_id) REFERENCES ticket_types(id),
-  CONSTRAINT fk_tickets_status FOREIGN KEY (status_id) REFERENCES ticket_statuses(id)
-) ENGINE=InnoDB;
+ALTER TABLE `user_roblox_identities`
+  ADD CONSTRAINT `user_roblox_identities_user_id_fkey` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;
 
-CREATE TABLE ticket_participants (
-  ticket_id INT UNSIGNED NOT NULL,
-  user_id BIGINT UNSIGNED NOT NULL,
-  role VARCHAR(24) NULL,
-  joined_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY (ticket_id, user_id),
-  INDEX idx_tp_user (user_id),
-  CONSTRAINT fk_tp_ticket FOREIGN KEY (ticket_id) REFERENCES tickets(id) ON DELETE CASCADE,
-  CONSTRAINT fk_tp_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
-) ENGINE=InnoDB;
+ALTER TABLE `middlemen`
+  ADD CONSTRAINT `middlemen_user_id_fkey` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT `middlemen_primary_roblox_identity_id_fkey` FOREIGN KEY (`primary_roblox_identity_id`) REFERENCES `user_roblox_identities` (`id`) ON DELETE SET NULL ON UPDATE CASCADE;
 
--- =========================================
--- Middlemen
--- =========================================
+ALTER TABLE `mm_trades`
+  ADD CONSTRAINT `mm_trades_ticket_id_fkey` FOREIGN KEY (`ticket_id`) REFERENCES `tickets` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT `mm_trades_user_id_fkey` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT `mm_trades_roblox_identity_id_fkey` FOREIGN KEY (`roblox_identity_id`) REFERENCES `user_roblox_identities` (`id`) ON DELETE SET NULL ON UPDATE CASCADE;
 
-CREATE TABLE middlemen (
-  user_id BIGINT UNSIGNED PRIMARY KEY, -- FK a users
-  roblox_username VARCHAR(255) NOT NULL,
-  roblox_user_id BIGINT UNSIGNED NULL,
-  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  INDEX idx_middlemen_roblox (roblox_user_id),
-  CONSTRAINT fk_middlemen_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
-) ENGINE=InnoDB;
+ALTER TABLE `mm_trade_items`
+  ADD CONSTRAINT `mm_trade_items_trade_id_fkey` FOREIGN KEY (`trade_id`) REFERENCES `mm_trades` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;
 
--- =========================================
--- Trades
--- =========================================
+ALTER TABLE `mm_claims`
+  ADD CONSTRAINT `mm_claims_ticket_id_fkey` FOREIGN KEY (`ticket_id`) REFERENCES `tickets` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT `mm_claims_middleman_id_fkey` FOREIGN KEY (`middleman_id`) REFERENCES `middlemen` (`user_id`) ON DELETE CASCADE ON UPDATE CASCADE;
 
-CREATE TABLE mm_trades (
-  id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-  ticket_id INT UNSIGNED NOT NULL,
-  user_id BIGINT UNSIGNED NOT NULL,
-  roblox_username VARCHAR(255) NOT NULL,
-  roblox_user_id BIGINT UNSIGNED NULL,
-  confirmed TINYINT(1) NOT NULL DEFAULT 0,
-  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  UNIQUE KEY uniq_mm_ticket_user (ticket_id, user_id),
-  INDEX idx_mm_trades_ticket (ticket_id),
-  CONSTRAINT fk_mmtr_ticket FOREIGN KEY (ticket_id) REFERENCES tickets(id) ON DELETE CASCADE,
-  CONSTRAINT fk_mmtr_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
-) ENGINE=InnoDB;
+ALTER TABLE `mm_reviews`
+  ADD CONSTRAINT `mm_reviews_ticket_id_fkey` FOREIGN KEY (`ticket_id`) REFERENCES `tickets` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT `mm_reviews_reviewer_id_fkey` FOREIGN KEY (`reviewer_id`) REFERENCES `users` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT `mm_reviews_middleman_id_fkey` FOREIGN KEY (`middleman_id`) REFERENCES `middlemen` (`user_id`) ON DELETE CASCADE ON UPDATE CASCADE;
 
-CREATE TABLE mm_trade_items (
-  id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-  trade_id INT UNSIGNED NOT NULL,
-  item_name VARCHAR(255) NOT NULL,
-  quantity INT NOT NULL DEFAULT 1,
-  metadata JSON NULL,
-  INDEX idx_trade_items_trade (trade_id),
-  CONSTRAINT fk_trade_items FOREIGN KEY (trade_id) REFERENCES mm_trades(id) ON DELETE CASCADE
-) ENGINE=InnoDB;
+ALTER TABLE `mm_trade_finalizations`
+  ADD CONSTRAINT `mm_trade_finalizations_ticket_id_fkey` FOREIGN KEY (`ticket_id`) REFERENCES `tickets` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT `mm_trade_finalizations_user_id_fkey` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;
 
--- =========================================
--- Claims / Reviews / Finalización
--- =========================================
+ALTER TABLE `member_trade_stats`
+  ADD CONSTRAINT `member_trade_stats_user_id_fkey` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT `member_trade_stats_preferred_roblox_identity_id_fkey` FOREIGN KEY (`preferred_roblox_identity_id`) REFERENCES `user_roblox_identities` (`id`) ON DELETE SET NULL ON UPDATE CASCADE;
 
-CREATE TABLE mm_claims (
-  ticket_id INT UNSIGNED PRIMARY KEY,
-  middleman_id BIGINT UNSIGNED NOT NULL,
-  claimed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  review_requested_at TIMESTAMP NULL,
-  closed_at TIMESTAMP NULL,
-  vouched TINYINT(1) NOT NULL DEFAULT 0,
-  forced_close TINYINT(1) NOT NULL DEFAULT 0,
-
-  panel_message_id BIGINT UNSIGNED NULL,
-  finalization_message_id BIGINT UNSIGNED NULL,
-  INDEX idx_claims_mm (middleman_id, claimed_at DESC),
-
-  CONSTRAINT fk_claim_ticket FOREIGN KEY (ticket_id) REFERENCES tickets(id) ON DELETE CASCADE,
-  CONSTRAINT fk_claim_middleman FOREIGN KEY (middleman_id) REFERENCES middlemen(user_id) ON DELETE CASCADE
-) ENGINE=InnoDB;
-
-CREATE TABLE mm_reviews (
-  id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-  ticket_id INT UNSIGNED NOT NULL,
-  reviewer_id BIGINT UNSIGNED NOT NULL,
-  middleman_id BIGINT UNSIGNED NOT NULL,
-  stars TINYINT NOT NULL CHECK (stars BETWEEN 0 AND 5),
-  review_text TEXT,
-  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  UNIQUE KEY uniq_ticket_reviewer (ticket_id, reviewer_id),
-  INDEX idx_reviews_mm (middleman_id, created_at DESC),
-  CONSTRAINT fk_reviews_ticket FOREIGN KEY (ticket_id) REFERENCES tickets(id) ON DELETE CASCADE,
-  CONSTRAINT fk_reviews_reviewer FOREIGN KEY (reviewer_id) REFERENCES users(id) ON DELETE CASCADE,
-  CONSTRAINT fk_reviews_middleman FOREIGN KEY (middleman_id) REFERENCES middlemen(user_id) ON DELETE CASCADE
-) ENGINE=InnoDB;
-
-CREATE TABLE mm_trade_finalizations (
-  ticket_id INT UNSIGNED NOT NULL,
-  user_id BIGINT UNSIGNED NOT NULL,
-  confirmed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY (ticket_id, user_id),
-  CONSTRAINT fk_mtf_ticket FOREIGN KEY (ticket_id) REFERENCES tickets(id) ON DELETE CASCADE,
-  CONSTRAINT fk_mtf_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
-) ENGINE=InnoDB;
-
--- =========================================
--- Estadísticas de miembros (solo acumulado)
--- =========================================
-
-CREATE TABLE member_trade_stats (
-  user_id BIGINT UNSIGNED PRIMARY KEY,
-  trades_completed INT NOT NULL DEFAULT 0,
-  last_trade_at TIMESTAMP NULL,
-  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  CONSTRAINT fk_mts_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
-) ENGINE=InnoDB;
-
-CREATE TABLE IF NOT EXISTS mm_trade_finalizations (
-  ticket_id INT NOT NULL,
-  user_id VARCHAR(20) NOT NULL,
-  confirmed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY (ticket_id, user_id),
-  CONSTRAINT fk_mtf_ticket FOREIGN KEY (ticket_id) REFERENCES tickets(id) ON DELETE CASCADE,
-  CONSTRAINT fk_mtf_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
-) ENGINE=InnoDB;
-
-
-CREATE TABLE IF NOT EXISTS member_trade_stats (
-  discord_user_id VARCHAR(20) PRIMARY KEY,
-  roblox_username VARCHAR(255) NULL,
-  roblox_user_id BIGINT NULL,
-  partner_roblox_username VARCHAR(255) NULL,
-  partner_roblox_user_id BIGINT NULL,
-  trades_completed INT NOT NULL DEFAULT 0,
-  last_trade_at TIMESTAMP NULL,
-  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  INDEX idx_member_trades_count (trades_completed DESC)
-) ENGINE=InnoDB;
+ALTER TABLE `guild_members`
+  ADD CONSTRAINT `guild_members_user_id_fkey` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/src/infrastructure/db/prisma.ts
+++ b/src/infrastructure/db/prisma.ts
@@ -2,10 +2,17 @@
 // RUTA: src/infrastructure/db/prisma.ts
 // ============================================================================
 
+import { execFile } from 'node:child_process';
+import { readdir } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { promisify } from 'node:util';
+
 import { PrismaClient } from '@prisma/client';
 
 import { env } from '@/shared/config/env';
 import { logger } from '@/shared/logger/pino';
+
+const execFileAsync = promisify(execFile);
 
 const createPrismaClient = () =>
   new PrismaClient({
@@ -23,8 +30,83 @@ if (env.NODE_ENV !== 'production') {
   globalForPrisma.prisma = prisma;
 }
 
+const prismaCli = process.platform === 'win32' ? 'npx.cmd' : 'npx';
+let schemaSynced = false;
+let schemaSyncPromise: Promise<void> | null = null;
+
+const detectMigrations = async (): Promise<boolean> => {
+  try {
+    const migrationsDir = resolve(process.cwd(), 'prisma', 'migrations');
+    const entries = await readdir(migrationsDir, { withFileTypes: true });
+    return entries.some((entry) => entry.isDirectory());
+  } catch (error) {
+    const knownError = error as NodeJS.ErrnoException;
+    if (knownError?.code !== 'ENOENT') {
+      logger.debug({ err: error }, 'Error inspeccionando directorio de migraciones.');
+    }
+
+    return false;
+  }
+};
+
+const runPrismaCli = async (args: string[]): Promise<void> => {
+  const command = `prisma ${args.join(' ')}`;
+  logger.info({ command }, 'Sincronizando esquema de base de datos.');
+
+  const { stdout, stderr } = await execFileAsync(prismaCli, ['prisma', ...args], {
+    cwd: process.cwd(),
+    env: process.env,
+  });
+
+  if (stdout.trim().length > 0) {
+    logger.debug({ command, stdout: stdout.trim() }, 'Salida de Prisma CLI.');
+  }
+
+  if (stderr.trim().length > 0) {
+    logger.warn({ command, stderr: stderr.trim() }, 'Prisma CLI reportó advertencias.');
+  }
+};
+
+const synchronizeSchemaInternal = async (): Promise<void> => {
+  if (!env.DB_AUTO_APPLY_SCHEMA) {
+    logger.info('Sincronización automática del esquema deshabilitada por configuración.');
+    return;
+  }
+
+  const hasMigrations = await detectMigrations();
+  const args = hasMigrations ? ['migrate', 'deploy'] : ['db', 'push', '--skip-generate'];
+
+  try {
+    await runPrismaCli(args);
+  } catch (error) {
+    logger.error({ err: error, command: `prisma ${args.join(' ')}` }, 'No fue posible sincronizar el esquema de Prisma.');
+    throw error;
+  }
+};
+
+export const synchronizeDatabaseSchema = async (): Promise<void> => {
+  if (schemaSynced) {
+    return;
+  }
+
+  if (!schemaSyncPromise) {
+    schemaSyncPromise = synchronizeSchemaInternal()
+      .then(() => {
+        schemaSynced = true;
+        logger.info('Esquema de base de datos sincronizado correctamente.');
+      })
+      .catch((error) => {
+        schemaSyncPromise = null;
+        throw error;
+      });
+  }
+
+  await schemaSyncPromise;
+};
+
 export const ensureDatabaseConnection = async (): Promise<void> => {
   try {
+    await synchronizeDatabaseSchema();
     await prisma.$connect();
     logger.debug('Conexión con Prisma establecida.');
   } catch (error) {

--- a/src/shared/config/env.ts
+++ b/src/shared/config/env.ts
@@ -79,6 +79,7 @@ export const EnvSchema = z.object({
     .optional()
     .default(';'),
   DATABASE_URL: z.string().url('DATABASE_URL debe ser una URL válida'),
+  DB_AUTO_APPLY_SCHEMA: booleanLike.default(true),
   MIDDLEMAN_CATEGORY_ID: z
     .string()
     .regex(/^\d{17,20}$/u, 'MIDDLEMAN_CATEGORY_ID debe ser un snowflake de Discord')


### PR DESCRIPTION
## Summary
- refresh the MySQL bootstrap script so it mirrors the current prisma/schema.prisma definition
- add a configurable flag and startup routine that runs Prisma CLI to keep the live schema in sync when the bot boots up

## Testing
- npm run typecheck *(fails: pre-existing Prisma type mismatches in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68def6219e148326b75a34a9ab5c56d8