### PR TITLE
Fix type errors in Prisma ticket repo and middleman commands

### DIFF
--- a/src/infrastructure/repositories/PrismaTicketRepository.ts
+++ b/src/infrastructure/repositories/PrismaTicketRepository.ts
@@ -16,7 +16,7 @@ import type { TransactionContext } from '@/domain/repositories/transaction';
 import { ensureUsersExist } from '@/infrastructure/repositories/utils/ensureUsersExist';
 import type { DiscordUserSnapshot } from '@/shared/types/discord';
 
-const OPEN_STATUSES: readonly TicketStatus[] = [
+const OPEN_STATUSES: TicketStatus[] = [
   TicketStatus.OPEN,
   TicketStatus.CONFIRMED,
   TicketStatus.CLAIMED,
@@ -160,7 +160,7 @@ export class PrismaTicketRepository implements ITicketRepository {
     const schema = await this.getSchemaMetadata();
 
     if (schema.mode === 'modern') {
-      const tickets = await this.prisma.ticket.findMany({
+      const tickets: PrismaTicketWithRelations[] = await this.prisma.ticket.findMany({
         where: {
           ownerId,
           status: { in: OPEN_STATUSES },

--- a/src/presentation/events/messageCreate.ts
+++ b/src/presentation/events/messageCreate.ts
@@ -35,6 +35,11 @@ export const messageCreateEvent: EventDescriptor<typeof Events.MessageCreate> = 
     }
 
     const [rawName, ...args] = content.split(/\s+/u);
+
+    if (!rawName) {
+      return;
+    }
+
     const commandName = rawName.toLowerCase();
     const command = prefixCommandRegistry.get(commandName);
 

--- a/src/presentation/middleman/TradePanelRenderer.ts
+++ b/src/presentation/middleman/TradePanelRenderer.ts
@@ -2,7 +2,7 @@
 // RUTA: src/presentation/middleman/TradePanelRenderer.ts
 // ============================================================================
 
-import type { TextChannel } from 'discord.js';
+import type { MessageCreateOptions, MessageEditOptions, TextChannel } from 'discord.js';
 import type { Logger } from 'pino';
 
 import { tradePanelStore } from '@/application/services/TradePanelStore';
@@ -90,10 +90,16 @@ export class TradePanelRenderer {
 
     const canConfirm = Boolean(ownerTrade && partnerTrade && !everyoneConfirmed);
 
-    const payload: Parameters<TextChannel['send']>[0] = {
+    const sendPayload: MessageCreateOptions = {
       embeds: [embed],
       components: [buildTradePanelButtons({ canConfirm })],
       allowedMentions: { parse: [] },
+    };
+
+    const editPayload: MessageEditOptions = {
+      embeds: sendPayload.embeds,
+      components: sendPayload.components,
+      allowedMentions: sendPayload.allowedMentions,
     };
 
     const storedMessageId = tradePanelStore.get(channel.id);
@@ -101,7 +107,7 @@ export class TradePanelRenderer {
     if (storedMessageId) {
       try {
         const message = await channel.messages.fetch(storedMessageId);
-        await message.edit(payload);
+        await message.edit(editPayload);
         return;
       } catch (error) {
         this.logger.warn(
@@ -112,7 +118,7 @@ export class TradePanelRenderer {
       }
     }
 
-    const message = await channel.send(payload);
+    const message = await channel.send(sendPayload);
     tradePanelStore.set(channel.id, message.id);
   }
 }


### PR DESCRIPTION
## Summary
- regenerate Prisma client types and relax ticket status constants to match mutable Prisma filters
- guard middleman command notifications behind sendable channel checks and prevent undefined command names
- adjust trade panel renderer payload types to use compatible create/edit options

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68def84381a88326ba03050135b24e7b