### PR TITLE
feat: redesign middleman cards and repair encoding

### DIFF
--- a/src/application/usecases/middleman/ClaimTradeUseCase.ts
+++ b/src/application/usecases/middleman/ClaimTradeUseCase.ts
@@ -96,17 +96,17 @@ export class ClaimTradeUseCase {
       ManageChannels: false,
     });
 
-    const infoEmbed = this.embeds.info({
-      title: '🛡️ Middleman asignado',
-      description: [
-        `**Aviso:** ${middlemanMention} ha reclamado este ticket.`,
-        '',
-        `**Middleman:** ${middlemanMention}`,
-        `**Roblox:** ${robloxUsername}`,
-        `**Vouches acumulados:** ${vouches}`,
-        `**Calificacion:** ${ratingLabel}`,
-      ].join('\n'),
-    });
+      const infoEmbed = this.embeds.info({
+        title: '🛡️ Middleman asignado',
+        description: [
+          `**Aviso:** ${middlemanMention} ha reclamado este ticket.`,
+          '',
+          `**Middleman:** ${middlemanMention}`,
+          `**Roblox:** ${robloxUsername}`,
+          `**Vouches acumulados:** ${vouches}`,
+          `**Calificación:** ${ratingLabel}`,
+        ].join('\n'),
+      });
 
     await channel.send(
       brandMessageOptions(

--- a/src/application/usecases/middleman/OpenMiddlemanChannelUseCase.ts
+++ b/src/application/usecases/middleman/OpenMiddlemanChannelUseCase.ts
@@ -1,4 +1,4 @@
-﻿// ============================================================================
+// ============================================================================
 // RUTA: src/application/usecases/middleman/OpenMiddlemanChannelUseCase.ts
 // ============================================================================
 
@@ -57,7 +57,7 @@ export class OpenMiddlemanChannelUseCase {
     const ownerId = BigInt(payload.userId);
     const guildId = BigInt(payload.guildId);
 
-    this.logger.debug({ ownerId: payload.userId }, 'Validando lÃ­mite de tickets abiertos.');
+    this.logger.debug({ ownerId: payload.userId }, 'Validando límite de tickets abiertos.');
     const openTickets = await this.ticketRepo.countOpenByOwner(ownerId);
     if (openTickets >= MAX_OPEN_TICKETS) {
       throw new TooManyOpenTicketsError(MAX_OPEN_TICKETS);
@@ -67,7 +67,7 @@ export class OpenMiddlemanChannelUseCase {
     const botId = guild.members.me?.id;
 
     if (!botId) {
-      throw new ChannelCreationError('El bot no estÃ¡ presente en el gremio.');
+      throw new ChannelCreationError('El bot no está presente en el gremio.');
     }
 
     this.logger.debug({ channelName, guildId: payload.guildId }, 'Creando canal de middleman.');
@@ -76,7 +76,7 @@ export class OpenMiddlemanChannelUseCase {
 
     if (!partnerId) {
       throw new ValidationFailedError({
-        partnerTag: 'Debes mencionar o introducir el ID de la persona con la que haras el trade.',
+        partnerTag: 'Debes mencionar o introducir el ID de la persona con la que harás el trade.',
       });
     }
 
@@ -149,7 +149,7 @@ export class OpenMiddlemanChannelUseCase {
           partnerId: partnerId.toString(),
           categoryId: payload.categoryId,
         },
-        'FallÃ³ la creaciÃ³n del canal de middleman.',
+        'Falló la creación del canal de middleman.',
       );
       throw new ChannelCreationError(String(error));
     }
@@ -221,11 +221,11 @@ export class OpenMiddlemanChannelUseCase {
         brandMessageOptions({
           embeds: [
             this.embeds.info({
-              title: 'InformaciÃ³n del trade',
+              title: 'Información del trade',
               description: [
                 '1. Completa tus datos con **Mis datos de trade**.',
-                '2. Confirma cuando estÃ©s listo usando **Confirmar trade**.',
-                '3. El equipo middleman serÃ¡ notificado despuÃ©s de que ambos traders confirmen.',
+                '2. Confirma cuando estés listo usando **Confirmar trade**.',
+                '3. El equipo middleman será notificado después de que ambos traders confirmen.',
               ].join('\n'),
             }),
           ],

--- a/src/domain/value-objects/MiddlemanCardConfig.ts
+++ b/src/domain/value-objects/MiddlemanCardConfig.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 /** #RRGGBB (6 dígitos) */
 const HEX_COLOR_PATTERN = /^#(?:[0-9A-Fa-f]{6})$/;
 
-const normalizeHex = (value: string): string => value.toUpperCase();
+export const normalizeHex = (value: string): string => value.toUpperCase();
 
 const clamp = (value: number, min: number, max: number): number => {
   if (Number.isNaN(value)) return min;
@@ -29,7 +29,7 @@ const hexToRgb = (value: string): [number, number, number] => {
   ];
 };
 
-const addAlphaToHex = (hex: string, alpha: number): string => {
+export const addAlphaToHex = (hex: string, alpha: number): string => {
   const [r, g, b] = hexToRgb(hex);
   const safeAlpha = clamp(alpha, 0, 1);
   return `rgba(${r}, ${g}, ${b}, ${safeAlpha.toFixed(2)})`;
@@ -102,7 +102,7 @@ const ChipsSchema = z.array(ChipEntrySchema).max(5).default([]);
 const VouchPanelSchema = z
   .object({
     label: optionalShortText(24).default('Vouches'),
-    secondaryLabel: optionalShortText(24).default('Resenas'),
+    secondaryLabel: optionalShortText(24).default('Reseñas'),
     accent: HexColorSchema.optional(),
   })
   .strict();

--- a/src/infrastructure/db/prisma.ts
+++ b/src/infrastructure/db/prisma.ts
@@ -105,7 +105,7 @@ const runPrismaCli = async (args: string[]): Promise<void> => {
 
 const synchronizeSchemaInternal = async (): Promise<void> => {
   if (!env.DB_AUTO_APPLY_SCHEMA) {
-    logger.info('SincronizaciÃ³n automÃ¡tica del esquema deshabilitada por configuraciÃ³n.');
+    logger.info('Sincronización automática del esquema deshabilitada por configuración.');
     return;
   }
 
@@ -148,7 +148,7 @@ export const ensureDatabaseConnection = async (): Promise<void> => {
   try {
     await synchronizeDatabaseSchema();
     await prisma.$connect();
-    logger.debug('ConexiÃ³n con Prisma establecida.');
+      logger.debug('Conexión con Prisma establecida.');
   } catch (error) {
     logger.error({ err: error }, 'No fue posible conectar con la base de datos.');
     throw error;

--- a/src/infrastructure/external/MiddlemanCardGenerator.ts
+++ b/src/infrastructure/external/MiddlemanCardGenerator.ts
@@ -2,52 +2,1016 @@
 // RUTA: src/infrastructure/external/MiddlemanCardGenerator.ts
 // ============================================================================
 
-import { createCanvas, loadImage, SKRSContext2D } from '@napi-rs/canvas'; 
-import { MiddlemanCardConfig, addAlphaToHex, normalizeHex } from '@/domain/value-objects/MiddlemanCardConfig'; 
-  
-export async function generateMiddlemanCard(config: MiddlemanCardConfig): Promise<Buffer> { 
-  const width = 800; 
-  const height = 400; 
-  const canvas = createCanvas(width, height); 
-  const ctx = canvas.getContext('2d') as any; // permite usar filter/globalAlpha 
-  
-  // --- Fondo degradado --- 
-  const gradient = ctx.createLinearGradient(0, 0, width, height); 
-  gradient.addColorStop(0, config.gradientStart ?? '#161129'); 
-  gradient.addColorStop(1, config.gradientEnd ?? '#221B41'); 
-  ctx.fillStyle = gradient; 
-  ctx.fillRect(0, 0, width, height); 
-  
-  // --- Avatar --- 
-  const avatarUrl = config.avatarUrl ?? 'https://cdn.discordapp.com/embed/avatars/0.png'; 
-  const avatarImg = await loadImage(avatarUrl); 
-  const avatarSize = 128; 
-  const avatarX = width / 2 - avatarSize / 2; 
-  const avatarY = 40; 
-  
-  ctx.save(); 
-  ctx.beginPath(); 
-  ctx.arc(width / 2, avatarY + avatarSize / 2, avatarSize / 2, 0, Math.PI * 2); 
-  ctx.closePath(); 
-  ctx.clip(); 
-  ctx.drawImage(avatarImg, avatarX, avatarY, avatarSize, avatarSize); 
-  ctx.restore(); 
-  
-  // --- Glow y filtro (con tipado correcto) --- 
-  ctx.filter = 'blur(16px)'; 
-  ctx.globalAlpha = 0.6; 
-  ctx.fillStyle = addAlphaToHex(config.accent ?? '#7C5CFF', 0.5); 
-  ctx.beginPath(); 
-  ctx.arc(width / 2, avatarY + avatarSize / 2, avatarSize / 1.8, 0, Math.PI * 2); 
-  ctx.fill(); 
-  ctx.globalAlpha = 1; 
-  ctx.filter = 'none'; 
-  
-  // --- Texto principal --- 
-  ctx.fillStyle = config.accentSoft ?? '#FFFFFF'; 
-  ctx.font = 'bold 36px "Segoe UI", sans-serif'; 
-  ctx.textAlign = 'center'; 
-  ctx.fillText('Dedos Middleman', width / 2, height - 60); 
-  
-  return canvas.toBuffer('image/png'); 
+import { createHash } from 'node:crypto';
+
+import { createCanvas, loadImage, type SKRSContext2D } from '@napi-rs/canvas';
+import { AttachmentBuilder } from 'discord.js';
+
+import type { MiddlemanProfile } from '@/domain/repositories/IMiddlemanRepository';
+import type {
+  MiddlemanCardBackground,
+  MiddlemanCardConfig,
+  MiddlemanCardSideMedia,
+  MiddlemanCardVouchPanel,
+} from '@/domain/value-objects/MiddlemanCardConfig';
+import { addAlphaToHex, DEFAULT_MIDDLEMAN_CARD_CONFIG } from '@/domain/value-objects/MiddlemanCardConfig';
+import { logger } from '@/shared/logger/pino';
+
+const CARD_WIDTH = 1280;
+const CARD_HEIGHT = 460;
+const AVATAR_SIZE = 182;
+const ROBLOX_AVATAR_SIZE = 78;
+const CACHE_TTL_MS = 5 * 60_000;
+
+const LAYOUT_SCALE: Record<MiddlemanCardConfig['layout'], number> = {
+  compact: 0.88,
+  standard: 1,
+  expanded: 1.15,
+};
+
+type CanvasImageSource = Parameters<SKRSContext2D['drawImage']>[0];
+
+type ExtendedContext = SKRSContext2D & {
+  filter?: string;
+  globalAlpha?: number;
+};
+
+interface ProfileCardOptions {
+  readonly discordTag: string;
+  readonly discordDisplayName?: string | null;
+  readonly discordAvatarUrl?: string | null;
+  readonly profile: MiddlemanProfile | null;
+  readonly highlight?: string | null;
 }
+
+interface TradeParticipantCardInfo {
+  readonly label: string;
+  readonly roblox?: string | null;
+  readonly status: 'pending' | 'confirmed' | 'delivered';
+  readonly items?: readonly string[] | null;
+}
+
+interface TradeSummaryCardOptions {
+  readonly ticketCode: string | number;
+  readonly middlemanTag: string;
+  readonly status: string;
+  readonly participants: readonly TradeParticipantCardInfo[];
+  readonly notes?: string | null;
+}
+
+interface StatsCardMetric {
+  readonly label: string;
+  readonly value: string;
+  readonly emphasis?: boolean;
+}
+
+interface StatsCardOptions {
+  readonly title: string;
+  readonly subtitle?: string | null;
+  readonly metrics: readonly StatsCardMetric[];
+}
+
+interface CacheEntry {
+  readonly buffer: Buffer;
+  readonly expiresAt: number;
+}
+
+interface ImageCacheEntry {
+  readonly image: CanvasImageSource;
+  readonly expiresAt: number;
+}
+
+const formatNumber = (value: number): string => {
+  if (value >= 1_000_000) {
+    return `${Math.round((value / 1_000_000) * 10) / 10}M`;
+  }
+
+  if (value >= 1000) {
+    return `${Math.round((value / 1000) * 10) / 10}k`;
+  }
+
+  return `${value}`;
+};
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.min(Math.max(value, min), max);
+
+const createCacheKey = (type: string, payload: unknown): string => {
+  const serialized = JSON.stringify(payload, (_key, value) =>
+    typeof value === 'bigint' ? value.toString() : value,
+  );
+
+  return createHash('sha1').update(`${type}:${serialized}`).digest('hex');
+};
+
+const traceRoundedRectPath = (
+  ctx: SKRSContext2D,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  radius: number,
+): void => {
+  ctx.beginPath();
+  ctx.moveTo(x + radius, y);
+  ctx.lineTo(x + width - radius, y);
+  ctx.quadraticCurveTo(x + width, y, x + width, y + radius);
+  ctx.lineTo(x + width, y + height - radius);
+  ctx.quadraticCurveTo(x + width, y + height, x + width - radius, y + height);
+  ctx.lineTo(x + radius, y + height);
+  ctx.quadraticCurveTo(x, y + height, x, y + height - radius);
+  ctx.lineTo(x, y + radius);
+  ctx.quadraticCurveTo(x, y, x + radius, y);
+  ctx.closePath();
+};
+
+const drawRoundedRect = (
+  ctx: SKRSContext2D,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  radius: number,
+  fillStyle: string,
+  strokeStyle?: string,
+  strokeWidth = 2,
+  shadow?: { color: string; blur: number },
+): void => {
+  ctx.save();
+  if (shadow) {
+    ctx.shadowColor = shadow.color;
+    ctx.shadowBlur = shadow.blur;
+  }
+
+  traceRoundedRectPath(ctx, x, y, width, height, radius);
+  ctx.fillStyle = fillStyle;
+  ctx.fill();
+
+  if (strokeStyle && strokeWidth > 0) {
+    ctx.shadowBlur = 0;
+    ctx.strokeStyle = strokeStyle;
+    ctx.lineWidth = strokeWidth;
+    ctx.stroke();
+  }
+
+  ctx.restore();
+};
+
+const traceStarPath = (
+  ctx: SKRSContext2D,
+  centerX: number,
+  centerY: number,
+  innerRadius: number,
+  outerRadius: number,
+  arms: number,
+): void => {
+  ctx.beginPath();
+  for (let step = 0; step < arms * 2; step += 1) {
+    const radius = step % 2 === 0 ? outerRadius : innerRadius;
+    const angle = (Math.PI * step) / arms - Math.PI / 2;
+    const pointX = centerX + radius * Math.cos(angle);
+    const pointY = centerY + radius * Math.sin(angle);
+    if (step === 0) {
+      ctx.moveTo(pointX, pointY);
+    } else {
+      ctx.lineTo(pointX, pointY);
+    }
+  }
+  ctx.closePath();
+};
+
+const drawPattern = (
+  ctx: SKRSContext2D,
+  pattern: MiddlemanCardConfig['pattern'],
+  accentColor: string,
+  width: number,
+  height: number,
+): void => {
+  if (pattern === 'none') {
+    return;
+  }
+
+  ctx.save();
+  ctx.strokeStyle = addAlphaToHex(accentColor, 0.08);
+  ctx.lineWidth = 1.2;
+  ctx.globalCompositeOperation = 'lighter';
+
+  switch (pattern) {
+    case 'grid': {
+      const step = 64;
+      for (let x = 0; x <= width; x += step) {
+        ctx.beginPath();
+        ctx.moveTo(x, 0);
+        ctx.lineTo(x, height);
+        ctx.stroke();
+      }
+      for (let y = 0; y <= height; y += step) {
+        ctx.beginPath();
+        ctx.moveTo(0, y);
+        ctx.lineTo(width, y);
+        ctx.stroke();
+      }
+      break;
+    }
+    case 'waves': {
+      const amplitude = 28;
+      const wavelength = 160;
+      for (let offset = -wavelength; offset < height + wavelength; offset += 72) {
+        ctx.beginPath();
+        for (let x = -wavelength; x <= width + wavelength; x += 4) {
+          const y = offset + Math.sin((x / wavelength) * Math.PI * 2) * amplitude;
+          if (x === -wavelength) {
+            ctx.moveTo(x, y);
+          } else {
+            ctx.lineTo(x, y);
+          }
+        }
+        ctx.stroke();
+      }
+      break;
+    }
+    case 'circuit': {
+      const step = 80;
+      for (let x = -step; x <= width + step; x += step) {
+        for (let y = -step; y <= height + step; y += step) {
+          ctx.beginPath();
+          ctx.arc(x, y, 6, 0, Math.PI * 2);
+          ctx.stroke();
+          ctx.beginPath();
+          ctx.moveTo(x, y);
+          ctx.lineTo(x + step / 2, y);
+          ctx.lineTo(x + step / 2, y + step / 2);
+          ctx.stroke();
+        }
+      }
+      break;
+    }
+    case 'mesh': {
+      const step = 56;
+      for (let x = -step; x <= width + step; x += step) {
+        for (let y = -step; y <= height + step; y += step) {
+          ctx.beginPath();
+          ctx.moveTo(x, y);
+          ctx.lineTo(x + step, y + step);
+          ctx.stroke();
+        }
+      }
+      break;
+    }
+    default:
+      break;
+  }
+
+  ctx.restore();
+};
+
+const createAvatarFallback = (initials: string, size: number): CanvasImageSource => {
+  const canvas = createCanvas(size, size);
+  const ctx = canvas.getContext('2d');
+  const gradient = ctx.createLinearGradient(0, 0, size, size);
+  gradient.addColorStop(0, '#2b2e57');
+  gradient.addColorStop(1, '#171a2f');
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, size, size);
+
+  ctx.fillStyle = '#ffffff';
+  ctx.font = `600 ${Math.round(size * 0.42)}px "Segoe UI", sans-serif`;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(initials.slice(0, 2).toUpperCase(), size / 2, size / 2);
+
+  return canvas as CanvasImageSource;
+};
+
+const resolveInitials = (value: string): string => {
+  const cleaned = value.replace(/[^\p{L}\p{N} ]+/gu, ' ').trim();
+  if (!cleaned) {
+    return 'MM';
+  }
+
+  const parts = cleaned
+    .split(/\s+/u)
+    .filter(Boolean)
+    .map((part) => part[0]?.toUpperCase() ?? '');
+
+  return (parts[0] ?? 'M') + (parts[1] ?? parts[0] ?? 'M');
+};
+
+const drawAvatar = (
+  ctx: SKRSContext2D,
+  source: CanvasImageSource,
+  x: number,
+  y: number,
+  size: number,
+  options?: { borderColor?: string; borderWidth?: number },
+): void => {
+  ctx.save();
+  traceRoundedRectPath(ctx, x, y, size, size, size / 2);
+  ctx.shadowColor = 'rgba(0, 0, 0, 0.4)';
+  ctx.shadowBlur = 28;
+  ctx.fillStyle = 'rgba(0, 0, 0, 0.35)';
+  ctx.fill();
+  ctx.clip();
+  ctx.shadowBlur = 0;
+  ctx.drawImage(source, x, y, size, size);
+  ctx.restore();
+
+  if (options?.borderColor && options.borderWidth && options.borderWidth > 0) {
+    ctx.save();
+    traceRoundedRectPath(ctx, x, y, size, size, size / 2);
+    ctx.strokeStyle = options.borderColor;
+    ctx.lineWidth = options.borderWidth;
+    ctx.stroke();
+    ctx.restore();
+  }
+};
+
+const drawRatingStars = (
+  ctx: SKRSContext2D,
+  rating: number,
+  x: number,
+  y: number,
+  size: number,
+  accent: string,
+  style: MiddlemanCardConfig['starStyle'],
+): void => {
+  const starCount = 5;
+  const spacing = size * 0.22;
+  const baseSize = size * 0.18;
+  const filledColor = accent;
+  const emptyColor = addAlphaToHex('#FFFFFF', 0.18);
+
+  for (let index = 0; index < starCount; index += 1) {
+    const centerX = x + index * (baseSize * 2 + spacing) + baseSize;
+    const centerY = y + baseSize;
+    const progress = clamp(rating - index, 0, 1);
+    const arms = style === 'rounded' ? 6 : 5;
+    const innerRadius = baseSize * (style === 'rounded' ? 0.52 : 0.5);
+    const outerRadius = baseSize * (style === 'rounded' ? 1.08 : 1.1);
+
+    ctx.save();
+    traceStarPath(ctx, centerX, centerY, innerRadius, outerRadius, arms);
+    ctx.fillStyle = emptyColor;
+    ctx.fill();
+
+    if (progress > 0) {
+      traceStarPath(ctx, centerX, centerY, innerRadius, outerRadius, arms);
+      ctx.clip();
+      const gradient = ctx.createLinearGradient(centerX - outerRadius, y, centerX + outerRadius, y + baseSize * 2);
+      gradient.addColorStop(0, filledColor);
+      gradient.addColorStop(1, addAlphaToHex(filledColor, 0.65));
+      ctx.fillStyle = gradient;
+      ctx.fillRect(centerX - outerRadius, y - baseSize, outerRadius * 2, baseSize * 3);
+    }
+
+    ctx.restore();
+  }
+};
+
+const drawChip = (
+  ctx: SKRSContext2D,
+  label: string,
+  accent: string,
+  x: number,
+  y: number,
+): number => {
+  const paddingX = 16;
+  ctx.font = '600 18px "Segoe UI", sans-serif';
+  const metrics = ctx.measureText(label);
+  const width = metrics.width + paddingX * 2;
+  const height = 32;
+  drawRoundedRect(ctx, x, y, width, height, 16, addAlphaToHex(accent, 0.16), addAlphaToHex(accent, 0.55));
+
+  ctx.fillStyle = accent;
+  const previousBaseline = ctx.textBaseline;
+  ctx.textBaseline = 'middle';
+  ctx.fillText(label, x + paddingX, y + height / 2);
+  ctx.textBaseline = previousBaseline;
+  return width + 12;
+};
+
+const drawVouchPanel = (
+  ctx: SKRSContext2D,
+  panel: MiddlemanCardVouchPanel,
+  vouches: number,
+  rating: number,
+  ratingCount: number,
+  x: number,
+  y: number,
+  width: number,
+): void => {
+  drawRoundedRect(
+    ctx,
+    x,
+    y,
+    width,
+    198,
+    26,
+    addAlphaToHex('#101226', 0.92),
+    addAlphaToHex(panel.accent, 0.35),
+    2.4,
+    { color: addAlphaToHex(panel.accent, 0.35), blur: 18 },
+  );
+
+  ctx.fillStyle = panel.accent;
+  ctx.font = '700 20px "Segoe UI", sans-serif';
+  ctx.fillText(panel.label.toUpperCase(), x + 24, y + 24);
+
+  ctx.fillStyle = '#ffffff';
+  ctx.font = '800 56px "Segoe UI", sans-serif';
+  ctx.fillText(formatNumber(vouches), x + 24, y + 62);
+
+  ctx.fillStyle = addAlphaToHex('#FFFFFF', 0.72);
+  ctx.font = '500 18px "Segoe UI", sans-serif';
+  ctx.fillText(panel.secondaryLabel, x + 24, y + 130);
+
+  const ratingLabel = ratingCount > 0 ? `${rating.toFixed(2)} · ${ratingCount} reseñas` : 'Sin reseñas registradas';
+  ctx.fillStyle = addAlphaToHex('#FFFFFF', 0.86);
+  ctx.font = '600 18px "Segoe UI", sans-serif';
+  ctx.fillText(ratingLabel, x + 24, y + 158);
+};
+
+const fetchImageBuffer = async (url: string): Promise<Buffer> => {
+  const response = await fetch(url, {
+    headers: {
+      'User-Agent': 'Mozilla/5.0 (compatible; DedosShopBot/1.0; +https://dedos.xyz)',
+      Accept: 'image/avif,image/webp,image/png,image/*;q=0.8,*/*;q=0.5',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+
+  return Buffer.from(await response.arrayBuffer());
+};
+
+const loadRemoteImage = async (
+  url: string,
+  cache: Map<string, ImageCacheEntry>,
+  cacheKey: string,
+): Promise<CanvasImageSource | null> => {
+  const now = Date.now();
+  const cached = cache.get(cacheKey);
+  if (cached && cached.expiresAt > now) {
+    return cached.image;
+  }
+
+  try {
+    const buffer = await fetchImageBuffer(url);
+    const image = await loadImage(buffer);
+    cache.set(cacheKey, { image, expiresAt: now + CACHE_TTL_MS });
+    return image;
+  } catch (error) {
+    logger.warn({ err: error, url }, 'No se pudo descargar la imagen remota.');
+    return null;
+  }
+};
+
+const buildRobloxAvatarUrl = (robloxUserId: bigint): string =>
+  `https://www.roblox.com/headshot-thumbnail/image?userId=${robloxUserId.toString()}&width=352&height=352&format=png`;
+
+const getImageMetrics = (
+  image: CanvasImageSource,
+): { width: number; height: number } | null => {
+  if (
+    typeof (image as { width?: unknown }).width === 'number' &&
+    typeof (image as { height?: unknown }).height === 'number'
+  ) {
+    return {
+      width: (image as { width: number }).width,
+      height: (image as { height: number }).height,
+    };
+  }
+
+  return null;
+};
+
+const drawBackgroundMedia = async (
+  ctx: SKRSContext2D,
+  background: MiddlemanCardBackground,
+  imageCache: Map<string, ImageCacheEntry>,
+): Promise<boolean> => {
+  const cacheKey = `bg:${background.url}`;
+  const image = await loadRemoteImage(background.url, imageCache, cacheKey);
+  if (!image) {
+    return false;
+  }
+
+  const metrics = getImageMetrics(image);
+  if (!metrics) {
+    return false;
+  }
+
+  const { width, height } = getScaledDimensions(metrics, background, CARD_WIDTH, CARD_HEIGHT);
+  const extended = ctx as ExtendedContext;
+  ctx.save();
+  if (extended.filter !== undefined) {
+    extended.filter = `blur(${background.blur}px) saturate(${background.saturate})`;
+  }
+  if (extended.globalAlpha !== undefined) {
+    extended.globalAlpha = background.opacity;
+  }
+  ctx.drawImage(image, (CARD_WIDTH - width) / 2, (CARD_HEIGHT - height) / 2, width, height);
+  ctx.restore();
+  return true;
+};
+
+const getScaledDimensions = (
+  metrics: { width: number; height: number },
+  background: MiddlemanCardBackground,
+  targetWidth: number,
+  targetHeight: number,
+): { width: number; height: number } => {
+  const aspect = metrics.width / metrics.height;
+  const targetAspect = targetWidth / targetHeight;
+
+  switch (background.fit) {
+    case 'cover': {
+      if (aspect > targetAspect) {
+        const height = targetHeight;
+        const width = height * aspect;
+        return { width, height };
+      }
+      return { width: targetWidth, height: targetWidth / aspect };
+    }
+    case 'contain': {
+      if (aspect > targetAspect) {
+        const width = targetWidth;
+        return { width, height: width / aspect };
+      }
+      const height = targetHeight;
+      return { width: height * aspect, height };
+    }
+    case 'fill':
+    default:
+      return { width: targetWidth, height: targetHeight };
+  }
+};
+
+const drawBackgroundLayer = async (
+  ctx: SKRSContext2D,
+  config: MiddlemanCardConfig,
+  imageCache: Map<string, ImageCacheEntry>,
+): Promise<void> => {
+  const gradient = ctx.createLinearGradient(0, 0, CARD_WIDTH, CARD_HEIGHT);
+  gradient.addColorStop(0, config.gradientStart);
+  gradient.addColorStop(1, config.gradientEnd);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, CARD_WIDTH, CARD_HEIGHT);
+
+  const hasMedia = config.background ? await drawBackgroundMedia(ctx, config.background, imageCache) : false;
+  if (!hasMedia) {
+    drawPattern(ctx, config.pattern, config.accent, CARD_WIDTH, CARD_HEIGHT);
+  }
+
+  const radial = ctx.createRadialGradient(CARD_WIDTH - 220, 120, 36, CARD_WIDTH - 180, 200, 420);
+  radial.addColorStop(0, addAlphaToHex(config.accentSoft, 0.9));
+  radial.addColorStop(1, addAlphaToHex(config.accentSoft, 0));
+  ctx.fillStyle = radial;
+  ctx.fillRect(0, 0, CARD_WIDTH, CARD_HEIGHT);
+
+  ctx.fillStyle = addAlphaToHex('#0B0D1A', 0.45);
+  ctx.fillRect(0, 0, CARD_WIDTH, CARD_HEIGHT);
+};
+
+const drawSideMedia = async (
+  ctx: SKRSContext2D,
+  sideMedia: MiddlemanCardSideMedia,
+  imageCache: Map<string, ImageCacheEntry>,
+): Promise<void> => {
+  const cacheKey = `side:${sideMedia.url}`;
+  const image = await loadRemoteImage(sideMedia.url, imageCache, cacheKey);
+  if (!image) {
+    return;
+  }
+
+  const metrics = getImageMetrics(image);
+  if (!metrics) {
+    return;
+  }
+
+  const width = sideMedia.width;
+  const aspect = metrics.width / metrics.height;
+  const height = sideMedia.fit === 'contain' ? width / aspect : CARD_HEIGHT;
+  const x = sideMedia.position === 'left' ? 48 : CARD_WIDTH - width - 48;
+  const y = (CARD_HEIGHT - height) / 2 + (sideMedia.offsetY ?? 0);
+
+  ctx.save();
+  const extended = ctx as ExtendedContext;
+  if (extended.globalAlpha !== undefined) {
+    extended.globalAlpha = clamp(sideMedia.opacity, 0, 1);
+  }
+  if (sideMedia.rounded) {
+    drawRoundedRect(ctx, x - 12, y - 12, width + 24, height + 24, 28, addAlphaToHex('#0B0D1A', 0.42));
+    traceRoundedRectPath(ctx, x, y, width, height, 24);
+    ctx.clip();
+  }
+  ctx.drawImage(image, x, y, width, height);
+  ctx.restore();
+};
+
+const drawWatermark = (ctx: SKRSContext2D, text: string): void => {
+  ctx.save();
+  ctx.font = '500 18px "Segoe UI", sans-serif';
+  ctx.fillStyle = addAlphaToHex('#FFFFFF', 0.45);
+  ctx.textAlign = 'right';
+  ctx.fillText(text, CARD_WIDTH - 72, CARD_HEIGHT - 48);
+  ctx.restore();
+};
+
+const drawBadge = (
+  ctx: SKRSContext2D,
+  x: number,
+  y: number,
+  label: string,
+  value: string,
+  accent: string,
+): void => {
+  drawRoundedRect(ctx, x, y, 190, 48, 18, addAlphaToHex(accent, 0.18), addAlphaToHex(accent, 0.45));
+  ctx.save();
+  ctx.fillStyle = addAlphaToHex(accent, 0.75);
+  ctx.font = '600 16px "Segoe UI", sans-serif';
+  ctx.fillText(label.toUpperCase(), x + 18, y + 10);
+  ctx.fillStyle = '#ffffff';
+  ctx.font = '700 20px "Segoe UI", sans-serif';
+  ctx.fillText(value, x + 18, y + 28);
+  ctx.restore();
+};
+
+const wrapText = (ctx: SKRSContext2D, text: string, maxWidth: number): string[] => {
+  const words = text.split(/\s+/u);
+  const lines: string[] = [];
+  let current = '';
+
+  for (const word of words) {
+    const candidate = current ? `${current} ${word}` : word;
+    if (ctx.measureText(candidate).width > maxWidth) {
+      if (current) {
+        lines.push(current);
+        current = word;
+      } else {
+        lines.push(candidate);
+        current = '';
+      }
+    } else {
+      current = candidate;
+    }
+  }
+
+  if (current) {
+    lines.push(current);
+  }
+
+  return lines;
+};
+
+class MiddlemanCardGenerator {
+  private readonly cache = new Map<string, CacheEntry>();
+
+  private readonly imageCache = new Map<string, ImageCacheEntry>();
+
+  private getFromCache(name: string, attachmentName: string): AttachmentBuilder | null {
+    const entry = this.cache.get(name);
+    if (entry && entry.expiresAt > Date.now()) {
+      return new AttachmentBuilder(entry.buffer, { name: attachmentName });
+    }
+
+    if (entry) {
+      this.cache.delete(name);
+    }
+
+    return null;
+  }
+
+  private storeInCache(name: string, buffer: Buffer): void {
+    this.cache.set(name, { buffer, expiresAt: Date.now() + CACHE_TTL_MS });
+  }
+
+  public async renderProfileCard(options: ProfileCardOptions): Promise<AttachmentBuilder | null> {
+    const profile = options.profile;
+    const config = profile?.cardConfig ?? DEFAULT_MIDDLEMAN_CARD_CONFIG;
+    const scale = LAYOUT_SCALE[config.layout] ?? 1;
+    const baseName = options.discordDisplayName?.trim() || options.discordTag.trim();
+    const cacheKey = createCacheKey('profile', {
+      tag: options.discordTag,
+      displayName: baseName,
+      avatar: options.discordAvatarUrl ?? null,
+      profile,
+      highlight: options.highlight ?? config.highlight ?? null,
+      cardConfig: config,
+    });
+
+    const cached = this.getFromCache(cacheKey, 'middleman-profile-card.png');
+    if (cached) {
+      return cached;
+    }
+
+    try {
+      const canvas = createCanvas(Math.round(CARD_WIDTH * scale), Math.round(CARD_HEIGHT * scale));
+      const ctx = canvas.getContext('2d');
+      ctx.scale(scale, scale);
+      ctx.textBaseline = 'top';
+
+      await drawBackgroundLayer(ctx, config, this.imageCache);
+      if (config.sideMedia) {
+        await drawSideMedia(ctx, config.sideMedia, this.imageCache);
+      }
+
+      const borderColor = addAlphaToHex(config.border.color, config.border.opacity);
+      drawRoundedRect(
+        ctx,
+        48,
+        80,
+        CARD_WIDTH - 96,
+        CARD_HEIGHT - 136,
+        config.frameStyle === 'cut' ? 12 : 34,
+        addAlphaToHex('#070916', 0.76),
+        borderColor,
+        config.border.width,
+        config.border.glow ? { color: addAlphaToHex(config.border.color, 0.35), blur: 24 } : undefined,
+      );
+
+      const initialsSource = profile?.primaryIdentity?.username ?? baseName;
+      const fallback = createAvatarFallback(resolveInitials(initialsSource), AVATAR_SIZE);
+      const discordAvatar =
+        options.discordAvatarUrl
+          ? await loadRemoteImage(options.discordAvatarUrl, this.imageCache, `discord:${options.discordAvatarUrl}`)
+          : null;
+      const avatarSource = discordAvatar ?? fallback;
+
+      const avatarX = 96;
+      const avatarY = 120;
+      drawAvatar(ctx, avatarSource, avatarX, avatarY, AVATAR_SIZE, {
+        borderColor: addAlphaToHex('#FFFFFF', 0.65),
+        borderWidth: 4,
+      });
+
+      const infoX = avatarX + AVATAR_SIZE + 48;
+      const infoWidth = CARD_WIDTH - infoX - 340;
+      const infoY = 128;
+
+      ctx.fillStyle = '#ffffff';
+      ctx.font = '700 52px "Segoe UI", sans-serif';
+      ctx.fillText(baseName.slice(0, 42), infoX, infoY);
+
+      ctx.fillStyle = addAlphaToHex('#FFFFFF', 0.76);
+      ctx.font = '500 22px "Segoe UI", sans-serif';
+      ctx.fillText(options.discordTag, infoX, infoY + 60);
+
+      const robloxUsername = profile?.primaryIdentity?.username ?? 'Sin registrar';
+      const robloxAvatarUrl = profile?.primaryIdentity?.robloxUserId
+        ? buildRobloxAvatarUrl(profile.primaryIdentity.robloxUserId)
+        : null;
+      const robloxAvatar = robloxAvatarUrl
+        ? await loadRemoteImage(robloxAvatarUrl, this.imageCache, `roblox:${robloxAvatarUrl}`)
+        : null;
+      const robloxCircleX = infoX;
+      const robloxCircleY = infoY + 100;
+      drawAvatar(
+        ctx,
+        robloxAvatar ?? createAvatarFallback(resolveInitials(robloxUsername), ROBLOX_AVATAR_SIZE),
+        robloxCircleX,
+        robloxCircleY,
+        ROBLOX_AVATAR_SIZE,
+        {
+          borderColor: addAlphaToHex(config.accent, 0.75),
+          borderWidth: 4,
+        },
+      );
+
+      ctx.fillStyle = '#ffffff';
+      ctx.font = '700 34px "Segoe UI", sans-serif';
+      ctx.fillText(`Roblox · ${robloxUsername}`, robloxCircleX + ROBLOX_AVATAR_SIZE + 24, robloxCircleY + 12);
+
+      if (profile?.primaryIdentity?.verified) {
+        ctx.fillStyle = addAlphaToHex('#3ED598', 0.92);
+        ctx.font = '600 18px "Segoe UI", sans-serif';
+        ctx.fillText('Verificado', robloxCircleX + ROBLOX_AVATAR_SIZE + 24, robloxCircleY + 60);
+      }
+
+      const ratingCount = profile?.ratingCount ?? 0;
+      const ratingTotal = profile?.ratingSum ?? 0;
+      const ratingValue = ratingCount > 0 ? clamp(ratingTotal / ratingCount, 0, 5) : 0;
+      const starsX = infoX;
+      const starsY = robloxCircleY + ROBLOX_AVATAR_SIZE + 12;
+      drawRatingStars(ctx, ratingValue, starsX, starsY, 96, config.accent, config.starStyle);
+      ctx.fillStyle = addAlphaToHex('#FFFFFF', 0.82);
+      ctx.font = '600 22px "Segoe UI", sans-serif';
+      const ratingLabel =
+        ratingCount > 0
+          ? `${ratingValue.toFixed(2)} / 5 (${ratingCount} reseñas)`
+          : 'Sin reseñas registradas';
+      ctx.fillText(ratingLabel, starsX + 360, starsY + 12);
+
+      let chipX = infoX;
+      const chipY = starsY + 90;
+      if (config.chips.length > 0) {
+        for (const chip of config.chips) {
+          const width = drawChip(ctx, chip.label, chip.accent ?? config.accent, chipX, chipY);
+          chipX += width;
+        }
+      }
+
+      const highlightText = options.highlight ?? config.highlight ?? null;
+      if (highlightText) {
+        ctx.fillStyle = addAlphaToHex('#FFFFFF', 0.7);
+        ctx.font = '500 20px "Segoe UI", sans-serif';
+        const lines = wrapText(ctx, highlightText, infoWidth);
+        lines.forEach((line, index) => {
+          ctx.fillText(line, infoX, chipY + 56 + index * 26);
+        });
+      }
+
+      if (config.customBadgeText) {
+        drawBadge(ctx, CARD_WIDTH - 320, infoY - 24, 'Rol', config.customBadgeText, config.accent);
+      }
+
+      const vouches = profile?.vouches ?? 0;
+      drawVouchPanel(
+        ctx,
+        config.vouchPanel,
+        vouches,
+        ratingValue,
+        ratingCount,
+        CARD_WIDTH - 320,
+        infoY + 52,
+        240,
+      );
+
+      if (config.watermark) {
+        drawWatermark(ctx, config.watermark);
+      }
+
+      const buffer = canvas.toBuffer('image/png');
+      this.storeInCache(cacheKey, buffer);
+      return new AttachmentBuilder(buffer, { name: 'middleman-profile-card.png' });
+    } catch (error) {
+      logger.warn({ err: error }, 'No se pudo generar la tarjeta de perfil del middleman.');
+      return null;
+    }
+  }
+
+  public async renderTradeSummaryCard(
+    options: TradeSummaryCardOptions,
+  ): Promise<AttachmentBuilder | null> {
+    const cacheKey = createCacheKey('trade-summary', options);
+    const cached = this.getFromCache(cacheKey, 'middleman-trade-card.png');
+    if (cached) {
+      return cached;
+    }
+
+    try {
+      const canvas = createCanvas(CARD_WIDTH, CARD_HEIGHT);
+      const ctx = canvas.getContext('2d');
+      ctx.textBaseline = 'top';
+
+      await drawBackgroundLayer(ctx, DEFAULT_MIDDLEMAN_CARD_CONFIG, this.imageCache);
+      drawRoundedRect(ctx, 48, 88, CARD_WIDTH - 96, CARD_HEIGHT - 160, 28, addAlphaToHex('#060815', 0.85), addAlphaToHex('#FFFFFF', 0.08));
+
+      ctx.fillStyle = '#ffffff';
+      ctx.font = '700 46px "Segoe UI", sans-serif';
+      ctx.fillText(`Ticket #${options.ticketCode}`, 82, 120);
+
+      ctx.fillStyle = addAlphaToHex('#FFFFFF', 0.72);
+      ctx.font = '500 22px "Segoe UI", sans-serif';
+      ctx.fillText(`Middleman asignado: ${options.middlemanTag}`, 82, 176);
+
+      ctx.fillStyle = DEFAULT_MIDDLEMAN_CARD_CONFIG.accent;
+      ctx.font = '600 20px "Segoe UI", sans-serif';
+      ctx.fillText(`Estado: ${options.status}`, 82, 210);
+
+      const participantWidth = 340;
+      const participantHeight = 156;
+      options.participants.slice(0, 3).forEach((participant, index) => {
+        const baseX = 82 + index * (participantWidth + 24);
+        const baseY = 252;
+        drawRoundedRect(
+          ctx,
+          baseX,
+          baseY,
+          participantWidth,
+          participantHeight,
+          24,
+          addAlphaToHex('#0B0D1A', 0.86),
+          addAlphaToHex('#FFFFFF', 0.12),
+        );
+
+        ctx.fillStyle = '#ffffff';
+        ctx.font = '600 24px "Segoe UI", sans-serif';
+        ctx.fillText(participant.label, baseX + 26, baseY + 24);
+
+        if (participant.roblox) {
+          ctx.fillStyle = addAlphaToHex('#FFFFFF', 0.72);
+          ctx.font = '500 18px "Segoe UI", sans-serif';
+          ctx.fillText(`Roblox · ${participant.roblox}`, baseX + 26, baseY + 58);
+        }
+
+        const statusPalette: Record<TradeParticipantCardInfo['status'], string> = {
+          pending: '#F6AD55',
+          confirmed: '#38BDF8',
+          delivered: '#34D399',
+        };
+        drawBadge(ctx, baseX + 26, baseY + 84, 'Estado', participant.status.toUpperCase(), statusPalette[participant.status]);
+
+        if (participant.items && participant.items.length > 0) {
+          ctx.fillStyle = addAlphaToHex('#FFFFFF', 0.6);
+          ctx.font = '400 16px "Segoe UI", sans-serif';
+          const items = participant.items.slice(0, 3).map((item) => `• ${item}`);
+          ctx.fillText(items.join('  '), baseX + 26, baseY + participantHeight - 32);
+        }
+      });
+
+      if (options.notes) {
+        drawRoundedRect(
+          ctx,
+          82,
+          CARD_HEIGHT - 140,
+          CARD_WIDTH - 164,
+          96,
+          20,
+          addAlphaToHex('#0B0D1A', 0.82),
+          addAlphaToHex('#FFFFFF', 0.12),
+        );
+        ctx.fillStyle = addAlphaToHex('#FFFFFF', 0.76);
+        ctx.font = '500 20px "Segoe UI", sans-serif';
+        const lines = wrapText(ctx, options.notes, CARD_WIDTH - 204);
+        lines.slice(0, 3).forEach((line, index) => {
+          ctx.fillText(line, 110, CARD_HEIGHT - 120 + index * 26);
+        });
+      }
+
+      const buffer = canvas.toBuffer('image/png');
+      this.storeInCache(cacheKey, buffer);
+      return new AttachmentBuilder(buffer, { name: 'middleman-trade-card.png' });
+    } catch (error) {
+      logger.warn({ err: error }, 'No se pudo generar la tarjeta de resumen de trade.');
+      return null;
+    }
+  }
+
+  public async renderStatsCard(options: StatsCardOptions): Promise<AttachmentBuilder | null> {
+    const cacheKey = createCacheKey('stats-card', options);
+    const cached = this.getFromCache(cacheKey, 'dedos-stats-card.png');
+    if (cached) {
+      return cached;
+    }
+
+    try {
+      const canvas = createCanvas(CARD_WIDTH, CARD_HEIGHT);
+      const ctx = canvas.getContext('2d');
+      ctx.textBaseline = 'top';
+
+      await drawBackgroundLayer(ctx, DEFAULT_MIDDLEMAN_CARD_CONFIG, this.imageCache);
+      drawRoundedRect(ctx, 64, 96, CARD_WIDTH - 128, CARD_HEIGHT - 176, 28, addAlphaToHex('#060815', 0.85), addAlphaToHex('#FFFFFF', 0.08));
+
+      ctx.fillStyle = '#ffffff';
+      ctx.font = '700 44px "Segoe UI", sans-serif';
+      ctx.fillText(options.title, 96, 128);
+
+      if (options.subtitle) {
+        ctx.fillStyle = addAlphaToHex('#FFFFFF', 0.72);
+        ctx.font = '500 22px "Segoe UI", sans-serif';
+        ctx.fillText(options.subtitle, 96, 180);
+      }
+
+      const columnWidth = (CARD_WIDTH - 256) / 3;
+      options.metrics.slice(0, 6).forEach((metric, index) => {
+        const column = index % 3;
+        const row = Math.floor(index / 3);
+        const x = 96 + column * (columnWidth + 32);
+        const y = 232 + row * 120;
+
+        drawRoundedRect(
+          ctx,
+          x,
+          y,
+          columnWidth,
+          96,
+          20,
+          addAlphaToHex('#0B0D1A', 0.82),
+          addAlphaToHex('#FFFFFF', 0.08),
+        );
+
+        ctx.fillStyle = addAlphaToHex('#FFFFFF', 0.65);
+        ctx.font = '600 18px "Segoe UI", sans-serif';
+        ctx.fillText(metric.label.toUpperCase(), x + 24, y + 18);
+
+        ctx.fillStyle = metric.emphasis ? '#ffffff' : addAlphaToHex('#FFFFFF', 0.86);
+        ctx.font = metric.emphasis ? '800 30px "Segoe UI", sans-serif' : '600 24px "Segoe UI", sans-serif';
+        ctx.fillText(metric.value, x + 24, y + 52);
+      });
+
+      const buffer = canvas.toBuffer('image/png');
+      this.storeInCache(cacheKey, buffer);
+      return new AttachmentBuilder(buffer, { name: 'dedos-stats-card.png' });
+    } catch (error) {
+      logger.warn({ err: error }, 'No se pudo generar la tarjeta de estadísticas.');
+      return null;
+    }
+  }
+}
+
+export const middlemanCardGenerator = new MiddlemanCardGenerator();
+
+export { MiddlemanCardGenerator };

--- a/src/presentation/commands/middleman/mm.ts
+++ b/src/presentation/commands/middleman/mm.ts
@@ -2,13 +2,19 @@
 // RUTA: src/presentation/commands/middleman/mm.ts
 // ============================================================================
 
-import type { ChatInputCommandInteraction, GuildMember, Message } from 'discord.js';
-import { MessageFlags, PermissionFlagsBits, SlashCommandBuilder } from 'discord.js';
+import {
+  type ChatInputCommandInteraction,
+  type GuildMember,
+  type Message,
+  MessageFlags,
+  PermissionFlagsBits,
+  SlashCommandBuilder,
+} from 'discord.js';
 
 import { parseMiddlemanCardConfig } from '@/domain/value-objects/MiddlemanCardConfig';
 import { prisma } from '@/infrastructure/db/prisma';
-import { middlemanCardGenerator } from '@/infrastructure/external/MiddlemanCardGenerator';
 import { memberCardGenerator } from '@/infrastructure/external/MemberCardGenerator';
+import { middlemanCardGenerator } from '@/infrastructure/external/MiddlemanCardGenerator';
 import { PrismaMemberStatsRepository } from '@/infrastructure/repositories/PrismaMemberStatsRepository';
 import { PrismaMiddlemanRepository } from '@/infrastructure/repositories/PrismaMiddlemanRepository';
 import type { Command } from '@/presentation/commands/types';

--- a/src/presentation/middleman/TradePanelRenderer.ts
+++ b/src/presentation/middleman/TradePanelRenderer.ts
@@ -159,7 +159,7 @@ export class TradePanelRenderer {
       } catch (error) {
         this.logger.warn(
           { channelId: channel.id, messageId: storedMessageId, err: error },
-          'No se pudo actualizar el panel existente, se enviarÃ¡ uno nuevo.',
+          'No se pudo actualizar el panel existente, se enviará uno nuevo.',
         );
         tradePanelStore.delete(channel.id);
       }

--- a/src/shared/errors/domain.errors.ts
+++ b/src/shared/errors/domain.errors.ts
@@ -1,4 +1,4 @@
-﻿// ============================================================================
+// ============================================================================
 // RUTA: src/shared/errors/domain.errors.ts
 // ============================================================================
 
@@ -8,7 +8,7 @@ export class TicketNotFoundError extends DedosError {
   public constructor(ticketId: string) {
     super({
       code: 'TICKET_NOT_FOUND',
-      message: `No se encontrÃ³ el ticket con identificador ${ticketId}.`,
+      message: `No se encontró el ticket con identificador ${ticketId}.`,
       metadata: { ticketId },
       exposeMessage: true,
     });
@@ -19,7 +19,7 @@ export class UnauthorizedActionError extends DedosError {
   public constructor(action: string) {
     super({
       code: 'UNAUTHORIZED_ACTION',
-      message: 'No tienes permisos para realizar esta acciÃ³n.',
+      message: 'No tienes permisos para realizar esta acción.',
       metadata: { action },
       exposeMessage: true,
     });
@@ -30,7 +30,7 @@ export class InvalidRatingError extends DedosError {
   public constructor(rating: number) {
     super({
       code: 'INVALID_RATING',
-      message: 'La valoraciÃ³n debe estar entre 1 y 5 estrellas.',
+      message: 'La valoración debe estar entre 1 y 5 estrellas.',
       metadata: { rating },
       exposeMessage: true,
     });
@@ -41,7 +41,7 @@ export class InvalidSnowflakeError extends DedosError {
   public constructor(value: string) {
     super({
       code: 'INVALID_SNOWFLAKE',
-      message: 'El identificador de Discord proporcionado no es vÃ¡lido.',
+      message: 'El identificador de Discord proporcionado no es válido.',
       metadata: { value },
       exposeMessage: true,
     });
@@ -52,7 +52,7 @@ export class InvalidTicketStateError extends DedosError {
   public constructor(current: unknown, expected: unknown) {
     super({
       code: 'INVALID_TICKET_STATE',
-      message: 'El ticket no se encuentra en un estado vÃ¡lido para esta operaciÃ³n.',
+      message: 'El ticket no se encuentra en un estado válido para esta operación.',
       metadata: { current, expected },
       exposeMessage: true,
     });
@@ -74,7 +74,7 @@ export class TooManyOpenTicketsError extends DedosError {
   public constructor(limit: number) {
     super({
       code: 'TOO_MANY_OPEN_TICKETS',
-      message: `Has alcanzado el lÃ­mite de ${limit} tickets abiertos simultÃ¡neamente.`,
+      message: `Has alcanzado el límite de ${limit} tickets abiertos simultáneamente.`,
       metadata: { limit },
       exposeMessage: true,
     });
@@ -85,7 +85,7 @@ export class InvalidTradeStateError extends DedosError {
   public constructor(current: unknown, expected: unknown) {
     super({
       code: 'INVALID_TRADE_STATE',
-      message: 'La transacciÃ³n no estÃ¡ en un estado vÃ¡lido para completar la operaciÃ³n.',
+      message: 'La transacción no está en un estado válido para completar la operación.',
       metadata: { current, expected },
       exposeMessage: true,
     });
@@ -96,7 +96,7 @@ export class TradesNotConfirmedError extends DedosError {
   public constructor(ticketId: number) {
     super({
       code: 'TRADES_NOT_CONFIRMED',
-      message: 'Existen participantes que no han confirmado la transacciÃ³n.',
+      message: 'Existen participantes que no han confirmado la transacción.',
       metadata: { ticketId },
       exposeMessage: true,
     });
@@ -106,7 +106,7 @@ export class FinalizationPendingError extends DedosError {
   public constructor(ticketId: number) {
     super({
       code: 'TRADE_FINALIZATION_PENDING',
-      message: 'Ambos traders deben confirmar que el intercambio se completo antes de cerrar el ticket.',
+      message: 'Ambos traders deben confirmar que el intercambio se completó antes de cerrar el ticket.',
       metadata: { ticketId },
       exposeMessage: true,
     });
@@ -129,7 +129,7 @@ export class TradeAlreadyConfirmedError extends DedosError {
   public constructor() {
     super({
       code: 'TRADE_ALREADY_CONFIRMED',
-      message: 'Ya confirmaste tu participaciÃ³n en este trade.',
+      message: 'Ya confirmaste tu participación en este trade.',
       exposeMessage: true,
     });
   }
@@ -173,7 +173,7 @@ export class MiddlemanNotFoundError extends DedosError {
   public constructor(userId: string) {
     super({
       code: 'MIDDLEMAN_NOT_FOUND',
-      message: 'El middleman solicitado no estÃ¡ disponible.',
+      message: 'El middleman solicitado no está disponible.',
       metadata: { userId },
       exposeMessage: true,
     });
@@ -184,7 +184,7 @@ export class TradeLimitExceededError extends DedosError {
   public constructor(limit: number) {
     super({
       code: 'TRADE_LIMIT_EXCEEDED',
-      message: 'Has alcanzado el lÃ­mite de transacciones simultÃ¡neas.',
+      message: 'Has alcanzado el límite de transacciones simultáneas.',
       metadata: { limit },
       exposeMessage: true,
     });
@@ -195,7 +195,7 @@ export class DuplicateReviewError extends DedosError {
   public constructor(ticketId: string, authorId: string) {
     super({
       code: 'DUPLICATE_REVIEW',
-      message: 'Ya has enviado una reseÃ±a para este ticket.',
+      message: 'Ya has enviado una reseña para este ticket.',
       metadata: { ticketId, authorId },
       exposeMessage: true,
     });
@@ -215,7 +215,7 @@ export class DiscordEntityCreationError extends DedosError {
 }
 
 export class DatabaseUnavailableError extends DedosError {
-  public constructor(message = 'La base de datos no estÃ¡ disponible en este momento.') {
+  public constructor(message = 'La base de datos no está disponible en este momento.') {
     super({
       code: 'DATABASE_UNAVAILABLE',
       message,
@@ -228,7 +228,7 @@ export class ValidationFailedError extends DedosError {
   public constructor(details: Record<string, unknown>) {
     super({
       code: 'VALIDATION_FAILED',
-      message: 'Los datos proporcionados no son vÃ¡lidos.',
+      message: 'Los datos proporcionados no son válidos.',
       metadata: details,
       exposeMessage: true,
     });


### PR DESCRIPTION
## Summary
- Rebuilt the middleman card generator with background layering, Roblox identity highlights, a vouch panel, and refreshed caching.
- Exported shared color helpers and corrected default labels in the middleman card configuration.
- Fixed Spanish copy throughout middleman flows and infrastructure logging to restore proper accents.

## Testing
- pnpm run typecheck
- pnpm run test
- pnpm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e22865dc4083269e75847d2e6c1492