### PR TITLE
Fix middleman card accent soft normalization

### DIFF
--- a/src/domain/value-objects/MiddlemanCardConfig.ts
+++ b/src/domain/value-objects/MiddlemanCardConfig.ts
@@ -199,10 +199,7 @@ const normalizeChips = (
 
 export const MiddlemanCardConfigSchema = MiddlemanCardConfigBaseSchema.transform(
   (config) => {
-    const accentSoft =
-      config.accentSoft != null
-        ? normalizeHex(config.accentSoft)
-        : addAlphaToHex(config.accent, 0.32);
+    const accentSoft = normalizeHex(config.accentSoft ?? config.accent);
 
     const background = config.background
       ? {


### PR DESCRIPTION
## Summary
- ensure middleman card configuration always normalizes accentSoft to a valid hex color to avoid NaN RGBA parsing errors

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e22e8b3fa08326b39cfcbe548d35e1