### PR TITLE
Fix drawAvatar invocation in middleman card generator

### DIFF
--- a/src/infrastructure/external/MiddlemanCardGenerator.ts
+++ b/src/infrastructure/external/MiddlemanCardGenerator.ts
@@ -825,7 +825,6 @@ class MiddlemanCardGenerator {
       const avatarBorderColor = shouldOverrideBorder && accentOverride ? accentOverride : config.avatarBorderColor;
       const avatarGlow = shouldOverrideGlow && accentOverride ? withAlpha(accentOverride, 0.6) : config.avatarGlow;
 
-
       drawAvatar(
         ctx,
         avatarSource,
@@ -833,10 +832,8 @@ class MiddlemanCardGenerator {
         132,
         AVATAR_SIZE,
         config.avatarStyle,
-<
         avatarBorderColor,
         avatarGlow,
-
       );
 
       const infoX = 82 + AVATAR_SIZE + 48;


### PR DESCRIPTION
## Summary
- remove an extraneous token from the `drawAvatar` invocation so the middleman card generator compiles with the new avatar styling options

## Testing
- pnpm typecheck *(fails: Prisma client types reject preferredRobloxIdentity fields in multiple repositories)*
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e2a5b820588326a9059f7f427eabeb