### PR TITLE
Fix GIF generation for middleman stats card

### DIFF
--- a/src/infrastructure/external/MiddlemanCardGenerator.ts
+++ b/src/infrastructure/external/MiddlemanCardGenerator.ts
@@ -59,9 +59,6 @@ const componentToHex = (value: number): string => value.toString(16).padStart(2,
 const rgbToHex = (r: number, g: number, b: number): string =>
   `#${componentToHex(r)}${componentToHex(g)}${componentToHex(b)}`;
 
-type GifEncoderInstance = InstanceType<typeof GIFEncoder>;
-type GifEncoderFrame = Parameters<GifEncoderInstance['addFrame']>[0];
-
 const encodeCanvasAsGif = (
   ctx: SKRSContext2D,
   width: number,
@@ -73,7 +70,7 @@ const encodeCanvasAsGif = (
   encoder.setRepeat(0);
   encoder.setDelay(Math.max(16, Math.round(options?.delayMs ?? 80)));
   encoder.setQuality(10);
-  encoder.addFrame(ctx as unknown as GifEncoderFrame);
+  encoder.addFrame(ctx);
   encoder.finish();
   return Buffer.from(encoder.out.getData());
 };
@@ -1084,10 +1081,10 @@ class MiddlemanCardGenerator {
         ctx.textAlign = 'left';
       }
 
-      const buffer = canvas.toBuffer('image/png');
+      const buffer = encodeCanvasAsGif(ctx, CARD_WIDTH, CARD_HEIGHT, { delayMs: 80 });
       this.storeInCache(cacheKey, buffer);
       logger.info({ cacheKey, title: options.title }, 'Tarjeta de estadisticas generada y almacenada en cache.');
-      return new AttachmentBuilder(buffer, { name: 'dedos-stats-card.png' });
+      return new AttachmentBuilder(buffer, { name: 'dedos-stats-card.gif' });
     } catch (error) {
       logger.warn({ err: error }, 'No se pudo generar la tarjeta de estadisticas animada.');
       return null;

--- a/src/presentation/commands/middleman/mm.ts
+++ b/src/presentation/commands/middleman/mm.ts
@@ -298,7 +298,7 @@ const handleStats = async (interaction: ChatInputCommandInteraction): Promise<vo
 
 
   const statsView = buildStatsViewModel(profile);
-
+  const { metrics, subtitleParts } = statsView;
 
   logger.info(
     {

--- a/src/types/gifencoder.d.ts
+++ b/src/types/gifencoder.d.ts
@@ -1,0 +1,26 @@
+declare module 'gifencoder' {
+  import type { EventEmitter } from 'node:events';
+
+  interface GIFEncoderOptions {
+    highWaterMark?: number;
+  }
+
+  class GIFEncoder extends EventEmitter {
+    constructor(width: number, height: number, options?: GIFEncoderOptions);
+
+    public createReadStream(): NodeJS.ReadableStream;
+    public start(): void;
+    public setRepeat(repeat: number): void;
+    public setDelay(ms: number): void;
+    public setQuality(quality: number): void;
+    public addFrame(imageData: unknown): void;
+    public finish(): void;
+
+    public readonly out: {
+      getData(): Uint8Array;
+    };
+  }
+
+  export { GIFEncoder, GIFEncoderOptions };
+  export = GIFEncoder;
+}

--- a/tests/setup-mocks.ts
+++ b/tests/setup-mocks.ts
@@ -101,3 +101,22 @@ vi.mock('@napi-rs/canvas', () => ({
   createCanvas: (width: number, height: number) => new MockCanvas(width, height),
   loadImage: async () => ({ width: 1, height: 1 }),
 }));
+
+vi.mock('gifencoder', () => {
+  class MockGifEncoder {
+    public readonly out = {
+      getData: () => new Uint8Array(0),
+    };
+
+    public constructor(_width: number, _height: number) {}
+
+    public start(): void {}
+    public setRepeat(_repeat: number): void {}
+    public setDelay(_ms: number): void {}
+    public setQuality(_quality: number): void {}
+    public addFrame(_frame: unknown): void {}
+    public finish(): void {}
+  }
+
+  return { default: MockGifEncoder };
+});

--- a/tests/simulation/full-bot-flow.test.ts
+++ b/tests/simulation/full-bot-flow.test.ts
@@ -854,7 +854,7 @@ describe('Simulación integral del bot', () => {
       createMockAttachment('profile-card.png'),
     );
     vi.spyOn(middlemanCardGenerator, 'renderStatsCard').mockResolvedValue(
-      createMockAttachment('stats-card.png'),
+      createMockAttachment('stats-card.gif'),
     );
     vi.spyOn(memberCardGenerator, 'render').mockResolvedValue(createMockAttachment('member-card.png'));
 


### PR DESCRIPTION
## Summary
- ensure the middleman stats command uses the generated metrics when building the stats card request
- encode stats cards as GIF attachments, cache them, and provide type declarations for gifencoder
- mock gifencoder in tests and update simulations to expect GIF assets

## Testing
- pnpm typecheck
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e2ba7e465c83269db82ca8c4e4abea