### PR TITLE
feat: enviar tarjetas del middleman como GIF animado

### DIFF
--- a/src/infrastructure/external/MiddlemanCardGenerator.ts
+++ b/src/infrastructure/external/MiddlemanCardGenerator.ts
@@ -85,7 +85,7 @@ interface ImageCacheEntry {
 }
 
 interface GifFrameData {
-  readonly image: CanvasImageSource;
+  readonly image: CanvasImageSource | null;
   readonly delay: number;
 }
 
@@ -979,16 +979,10 @@ class MiddlemanCardGenerator {
     });
 
     const gifCacheKey = `${baseCacheKey}:gif`;
-    const pngCacheKey = `${baseCacheKey}:png`;
 
     const cachedGif = this.getFromCache(gifCacheKey, 'middleman-profile-card.gif');
     if (cachedGif) {
       return cachedGif;
-    }
-
-    const cachedPng = this.getFromCache(pngCacheKey, 'middleman-profile-card.png');
-    if (cachedPng) {
-      return cachedPng;
     }
 
     try {
@@ -1165,14 +1159,15 @@ class MiddlemanCardGenerator {
         return new AttachmentBuilder(buffer, { name: 'middleman-profile-card.gif' });
       }
 
-      const canvas = createCanvas(Math.round(CARD_WIDTH * scale), Math.round(CARD_HEIGHT * scale));
-      const ctx = canvas.getContext('2d');
-      ctx.scale(scale, scale);
-      await drawFrame(ctx, null);
-
-      const buffer = canvas.toBuffer('image/png');
-      this.storeInCache(pngCacheKey, buffer);
-      return new AttachmentBuilder(buffer, { name: 'middleman-profile-card.png' });
+      const buffer = await this.renderAnimatedCard({
+        frames: [{ image: null, delay: 200 }],
+        width: Math.round(CARD_WIDTH * scale),
+        height: Math.round(CARD_HEIGHT * scale),
+        scale,
+        draw: drawFrame,
+      });
+      this.storeInCache(gifCacheKey, buffer);
+      return new AttachmentBuilder(buffer, { name: 'middleman-profile-card.gif' });
     } catch (error) {
       logger.warn({ err: error }, 'No se pudo generar la tarjeta de perfil del middleman.');
       return null;
@@ -1184,16 +1179,10 @@ class MiddlemanCardGenerator {
   ): Promise<AttachmentBuilder | null> {
     const baseCacheKey = createCacheKey('trade-summary', options);
     const gifCacheKey = `${baseCacheKey}:gif`;
-    const pngCacheKey = `${baseCacheKey}:png`;
 
     const cachedGif = this.getFromCache(gifCacheKey, 'middleman-trade-card.gif');
     if (cachedGif) {
       return cachedGif;
-    }
-
-    const cachedPng = this.getFromCache(pngCacheKey, 'middleman-trade-card.png');
-    if (cachedPng) {
-      return cachedPng;
     }
 
     try {
@@ -1319,13 +1308,15 @@ class MiddlemanCardGenerator {
         return new AttachmentBuilder(buffer, { name: 'middleman-trade-card.gif' });
       }
 
-      const canvas = createCanvas(CARD_WIDTH, CARD_HEIGHT);
-      const ctx = canvas.getContext('2d');
-      await drawFrame(ctx, null);
-
-      const buffer = canvas.toBuffer('image/png');
-      this.storeInCache(pngCacheKey, buffer);
-      return new AttachmentBuilder(buffer, { name: 'middleman-trade-card.png' });
+      const buffer = await this.renderAnimatedCard({
+        frames: [{ image: null, delay: 200 }],
+        width: CARD_WIDTH,
+        height: CARD_HEIGHT,
+        scale: 1,
+        draw: drawFrame,
+      });
+      this.storeInCache(gifCacheKey, buffer);
+      return new AttachmentBuilder(buffer, { name: 'middleman-trade-card.gif' });
     } catch (error) {
       logger.warn({ err: error }, 'No se pudo generar la tarjeta de resumen de trade.');
       return null;
@@ -1335,16 +1326,10 @@ class MiddlemanCardGenerator {
   public async renderStatsCard(options: StatsCardOptions): Promise<AttachmentBuilder | null> {
     const baseCacheKey = createCacheKey('stats-card', options);
     const gifCacheKey = `${baseCacheKey}:gif`;
-    const pngCacheKey = `${baseCacheKey}:png`;
 
     const cachedGif = this.getFromCache(gifCacheKey, 'dedos-stats-card.gif');
     if (cachedGif) {
       return cachedGif;
-    }
-
-    const cachedPng = this.getFromCache(pngCacheKey, 'dedos-stats-card.png');
-    if (cachedPng) {
-      return cachedPng;
     }
 
     try {
@@ -1428,13 +1413,15 @@ class MiddlemanCardGenerator {
         return new AttachmentBuilder(buffer, { name: 'dedos-stats-card.gif' });
       }
 
-      const canvas = createCanvas(CARD_WIDTH, CARD_HEIGHT);
-      const ctx = canvas.getContext('2d');
-      await drawFrame(ctx, null);
-
-      const buffer = canvas.toBuffer('image/png');
-      this.storeInCache(pngCacheKey, buffer);
-      return new AttachmentBuilder(buffer, { name: 'dedos-stats-card.png' });
+      const buffer = await this.renderAnimatedCard({
+        frames: [{ image: null, delay: 200 }],
+        width: CARD_WIDTH,
+        height: CARD_HEIGHT,
+        scale: 1,
+        draw: drawFrame,
+      });
+      this.storeInCache(gifCacheKey, buffer);
+      return new AttachmentBuilder(buffer, { name: 'dedos-stats-card.gif' });
     } catch (error) {
       logger.warn({ err: error }, 'No se pudo generar la tarjeta de estadísticas.');
       return null;

--- a/tests/setup-mocks.ts
+++ b/tests/setup-mocks.ts
@@ -1,3 +1,5 @@
+import { Readable } from 'node:stream';
+
 import { vi } from 'vitest';
 
 class MockCanvasContext {
@@ -27,6 +29,14 @@ class MockCanvasContext {
   public scale(_x: number, _y: number): void {}
   public translate(_x: number, _y: number): void {}
   public rotate(_angle: number): void {}
+  public setTransform(
+    _a: number,
+    _b: number,
+    _c: number,
+    _d: number,
+    _e: number,
+    _f: number,
+  ): void {}
   public beginPath(): void {}
   public closePath(): void {}
   public moveTo(_x: number, _y: number): void {}
@@ -100,4 +110,38 @@ class MockCanvas {
 vi.mock('@napi-rs/canvas', () => ({
   createCanvas: (width: number, height: number) => new MockCanvas(width, height),
   loadImage: async () => ({ width: 1, height: 1 }),
+}));
+
+vi.mock('gifencoder', () => {
+  class MockGifEncoder {
+    private readonly stream = new Readable({ read() {} });
+
+    public start(): void {}
+
+    public setRepeat(_value: number): void {}
+
+    public setQuality(_value: number): void {}
+
+    public setDelay(_value: number): void {}
+
+    public addFrame(_ctx: unknown): void {}
+
+    public createReadStream(): Readable {
+      return this.stream;
+    }
+
+    public finish(): void {
+      this.stream.push(Buffer.from('gif'));
+      this.stream.push(null);
+    }
+  }
+
+  return { default: MockGifEncoder };
+});
+
+vi.mock('gifuct-js', () => ({
+  parseGIF: () => ({
+    lsd: { width: 1, height: 1 },
+  }),
+  decompressFrames: () => [],
 }));

--- a/tests/simulation/full-bot-flow.test.ts
+++ b/tests/simulation/full-bot-flow.test.ts
@@ -848,13 +848,13 @@ describe('Simulación integral del bot', () => {
     const fakeLogger = new FakeLogger();
 
     vi.spyOn(middlemanCardGenerator, 'renderTradeSummaryCard').mockResolvedValue(
-      createMockAttachment('trade-card.png'),
+      createMockAttachment('trade-card.gif'),
     );
     vi.spyOn(middlemanCardGenerator, 'renderProfileCard').mockResolvedValue(
-      createMockAttachment('profile-card.png'),
+      createMockAttachment('profile-card.gif'),
     );
     vi.spyOn(middlemanCardGenerator, 'renderStatsCard').mockResolvedValue(
-      createMockAttachment('stats-card.png'),
+      createMockAttachment('stats-card.gif'),
     );
     vi.spyOn(memberCardGenerator, 'render').mockResolvedValue(createMockAttachment('member-card.png'));
 


### PR DESCRIPTION
## Summary
- renderizar las tarjetas de middleman y estadísticas siempre en GIF usando el encoder animado
- actualizar caché y nombres de archivos adjuntos para reflejar el nuevo formato
- extender los mocks de pruebas para cubrir gifencoder/gifuct-js y ajustar las expectativas de adjuntos

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e32f96dd94832697b1a3439f78835a